### PR TITLE
Updated README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains the smart contracts source code and markets configurati
 
 ## What is BendDAO Lending Protocol?
 
-BendDAO Lending Protocol is a decentralized non-custodial NFT lending protocol where users can participate as depositors or borrowers. Depositors provide liquidity to the market to earn a passive income, while borrowers are able to borrow in an overcollateralized fashion, using NFTs as collaterl.
+BendDAO Lending Protocol is a decentralized non-custodial NFT lending protocol where users can participate as depositors or borrowers. Depositors provide liquidity to the market to earn a passive income, while borrowers are able to borrow in an overcollateralized fashion, using NFTs as collateral.
 
 ## Documentation
 


### PR DESCRIPTION
Found a typo on the README.md from https://github.com/BendDAO/bend-lending-protocol#what-is-benddao-lending-protocol, just want to get this typo fixed so user won't get confused with the word "collateral" for NFT Lending & Borrowing