### PR TITLE
Add wrapper gateway contract

### DIFF
--- a/abis/WrapperGateway.json
+++ b/abis/WrapperGateway.json
@@ -1,0 +1,712 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EmergencyEtherTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [],
+    "name": "addressProvider",
+    "outputs": [
+      {
+        "internalType": "contract ILendPoolAddressesProvider",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bidPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      }
+    ],
+    "name": "auction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      }
+    ],
+    "name": "auctionETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "callers",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "flag",
+        "type": "bool"
+      }
+    ],
+    "name": "authorizeCallerWhitelist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "authorizeLendPoolERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "reserveAssets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "referralCode",
+        "type": "uint16"
+      }
+    ],
+    "name": "batchBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "nftTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "referralCode",
+        "type": "uint16"
+      }
+    ],
+    "name": "batchBorrowETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "nftTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchRepay",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "nftTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchRepayETH",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reserveAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "referralCode",
+        "type": "uint16"
+      }
+    ],
+    "name": "borrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "onBehalfOf",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "referralCode",
+        "type": "uint16"
+      }
+    ],
+    "name": "borrowETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyERC20Transfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyERC721Transfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyEtherTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "punks",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyPunksTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addressProvider_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "wethGateway_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "underlyingToken_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "wrappedToken_",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "isCallerInWhitelist",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "liquidateETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bidFine",
+        "type": "uint256"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bidFine",
+        "type": "uint256"
+      }
+    ],
+    "name": "redeemETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "nftTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repayETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlyingToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC721Upgradeable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wethGateway",
+    "outputs": [
+      {
+        "internalType": "contract IWETHGateway",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "wrappedToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC721Wrapper",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/contracts/interfaces/IERC721Wrapper.sol
+++ b/contracts/interfaces/IERC721Wrapper.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+import {IERC721MetadataUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721MetadataUpgradeable.sol";
+
+interface IERC721Wrapper is IERC721MetadataUpgradeable {
+  function mint(uint256 tokenId) external;
+
+  function burn(uint256 tokenId) external;
+}

--- a/contracts/interfaces/IWrapperGateway.sol
+++ b/contracts/interfaces/IWrapperGateway.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+interface IWrapperGateway {
+  /**
+   * @dev Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+   * already deposited enough collateral
+   * - E.g. User borrows 100 USDC, receiving the 100 USDC in his wallet
+   *   and lock collateral asset in contract
+   * @param reserveAsset The address of the underlying asset to borrow
+   * @param amount The amount to be borrowed
+   * @param nftTokenId The index of the ERC721 used as collteral
+   * @param onBehalfOf Address of the user who will receive the loan. Should be the address of the borrower itself
+   * calling the function if he wants to borrow against his own collateral, or the address of the credit delegator
+   * if he has been given credit delegation allowance
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   **/
+  function borrow(
+    address reserveAsset,
+    uint256 amount,
+    uint256 nftTokenId,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  function batchBorrow(
+    address[] calldata reserveAssets,
+    uint256[] calldata amounts,
+    uint256[] calldata nftTokenIds,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @notice Repays a borrowed `amount` on a specific NFT, burning the equivalent loan owned
+   * - E.g. User repays 100 USDC, burning loan and receives collateral asset
+   * @param nftTokenId The index of the ERC721 used as collteral
+   * @param amount The amount to repay
+   * @return The final amount repaid, loan is burned or not
+   **/
+  function repay(uint256 nftTokenId, uint256 amount) external returns (uint256, bool);
+
+  function batchRepay(uint256[] calldata nftTokenIds, uint256[] calldata amounts)
+    external
+    returns (uint256[] memory, bool[] memory);
+
+  /**
+   * @notice auction a unhealth NFT loan with ERC20 reserve
+   * @param nftTokenId The index of the ERC721 used as collteral
+   * @param bidPrice The bid price
+   **/
+  function auction(
+    uint256 nftTokenId,
+    uint256 bidPrice,
+    address onBehalfOf
+  ) external;
+
+  /**
+   * @notice redeem a unhealth NFT loan with ERC20 reserve
+   * @param nftTokenId The index of the ERC721 used as collteral
+   * @param amount The amount to repay the debt
+   * @param bidFine The amount of bid fine
+   **/
+  function redeem(
+    uint256 nftTokenId,
+    uint256 amount,
+    uint256 bidFine
+  ) external returns (uint256);
+
+  /**
+   * @notice liquidate a unhealth NFT loan with ERC20 reserve
+   * @param nftTokenId The index of the ERC721 used as collteral
+   **/
+  function liquidate(uint256 nftTokenId, uint256 amount) external returns (uint256);
+
+  /**
+   * @dev Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+   * already deposited enough collateral
+   * - E.g. User borrows 100 ETH, receiving the 100 ETH in his wallet
+   *   and lock collateral asset in contract
+   * @param amount The amount to be borrowed
+   * @param nftTokenId The index of the ERC721 to deposit
+   * @param onBehalfOf Address of the user who will receive the loan. Should be the address of the borrower itself
+   * calling the function if he wants to borrow against his own collateral, or the address of the credit delegator
+   * if he has been given credit delegation allowance
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   **/
+  function borrowETH(
+    uint256 amount,
+    uint256 nftTokenId,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  function batchBorrowETH(
+    uint256[] calldata amounts,
+    uint256[] calldata nftTokenIds,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @notice Repays a borrowed `amount` on a specific NFT with native ETH
+   * - E.g. User repays 100 ETH, burning loan and receives collateral asset
+   * @param nftTokenId The index of the ERC721 to repay
+   * @param amount The amount to repay
+   * @return The final amount repaid, loan is burned or not
+   **/
+  function repayETH(uint256 nftTokenId, uint256 amount) external payable returns (uint256, bool);
+
+  function batchRepayETH(uint256[] calldata nftTokenIds, uint256[] calldata amounts)
+    external
+    payable
+    returns (uint256[] memory, bool[] memory);
+
+  /**
+   * @notice auction a unhealth NFT loan with native ETH
+   * @param nftTokenId The index of the ERC721 to repay
+   * @param onBehalfOf Address of the user who will receive the ERC721. Should be the address of the user itself
+   * calling the function if he wants to get collateral
+   **/
+  function auctionETH(uint256 nftTokenId, address onBehalfOf) external payable;
+
+  /**
+   * @notice liquidate a unhealth NFT loan with native ETH
+   * @param nftTokenId The index of the ERC721 to repay
+   * @param amount The amount to repay the debt
+   * @param bidFine The amount of bid fine
+   **/
+  function redeemETH(
+    uint256 nftTokenId,
+    uint256 amount,
+    uint256 bidFine
+  ) external payable returns (uint256);
+
+  /**
+   * @notice liquidate a unhealth NFT loan with native ETH
+   * @param nftTokenId The index of the ERC721 to repay
+   **/
+  function liquidateETH(uint256 nftTokenId) external payable returns (uint256);
+}

--- a/contracts/mock/MockERC721Wrapper.sol
+++ b/contracts/mock/MockERC721Wrapper.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+
+contract MockerERC721Wrapper is ERC721Enumerable, ERC721Holder {
+  string public baseURI;
+  IERC721 public underlyingToken;
+
+  constructor(
+    address underlyingToken_,
+    string memory name,
+    string memory symbol
+  ) ERC721(name, symbol) {
+    baseURI = "https://MintableERC721/";
+
+    underlyingToken = IERC721(underlyingToken_);
+  }
+
+  function mint(uint256 tokenId) public {
+    require(underlyingToken.ownerOf(tokenId) == _msgSender(), "MockerERC721Wrapper: caller not owner");
+
+    underlyingToken.safeTransferFrom(_msgSender(), address(this), tokenId);
+
+    _mint(_msgSender(), tokenId);
+  }
+
+  function burn(uint256 tokenId) public {
+    require(ownerOf(tokenId) == _msgSender(), "MockerERC721Wrapper: caller not owner");
+
+    _burn(tokenId);
+
+    underlyingToken.safeTransferFrom(address(this), _msgSender(), tokenId);
+  }
+
+  function _baseURI() internal view virtual override returns (string memory) {
+    return baseURI;
+  }
+
+  function setBaseURI(string memory baseURI_) public {
+    baseURI = baseURI_;
+  }
+}

--- a/contracts/protocol/PunkGateway.sol
+++ b/contracts/protocol/PunkGateway.sol
@@ -116,6 +116,9 @@ contract PunkGateway is IPunkGateway, ERC721HolderUpgradeable, EmergencyTokenRec
       return;
     }
 
+    // !!! CAUTION: MUST CHECK THE OWNERSHIP HERE !!!
+    // Beware many holders can sell the punk to this gateway at the same time.
+    // If we do not check the ownership, attacker can borrow eth using victime's punk.
     address owner = punks.punkIndexToAddress(punkIndex);
     require(owner == _msgSender(), "PunkGateway: not owner of punkIndex");
 

--- a/contracts/protocol/WrapperGateway.sol
+++ b/contracts/protocol/WrapperGateway.sol
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {SafeERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import {ERC721HolderUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/utils/ERC721HolderUpgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+
+import {Errors} from "../libraries/helpers/Errors.sol";
+import {ILendPool} from "../interfaces/ILendPool.sol";
+import {ILendPoolLoan} from "../interfaces/ILendPoolLoan.sol";
+import {ILendPoolAddressesProvider} from "../interfaces/ILendPoolAddressesProvider.sol";
+import {IWrapperGateway} from "../interfaces/IWrapperGateway.sol";
+import {IERC721Wrapper} from "../interfaces/IERC721Wrapper.sol";
+import {DataTypes} from "../libraries/types/DataTypes.sol";
+import {IWETHGateway} from "../interfaces/IWETHGateway.sol";
+
+import {EmergencyTokenRecoveryUpgradeable} from "./EmergencyTokenRecoveryUpgradeable.sol";
+
+contract WrapperGateway is
+  IWrapperGateway,
+  ReentrancyGuardUpgradeable,
+  ERC721HolderUpgradeable,
+  EmergencyTokenRecoveryUpgradeable
+{
+  using SafeERC20Upgradeable for IERC20Upgradeable;
+
+  ILendPoolAddressesProvider public addressProvider;
+  IWETHGateway public wethGateway;
+
+  IERC721Upgradeable public underlyingToken;
+  IERC721Wrapper public wrappedToken;
+
+  mapping(address => bool) internal _callerWhitelists;
+
+  function initialize(
+    address addressProvider_,
+    address wethGateway_,
+    address underlyingToken_,
+    address wrappedToken_
+  ) public initializer {
+    __ReentrancyGuard_init();
+    __ERC721Holder_init();
+    __EmergencyTokenRecovery_init();
+
+    addressProvider = ILendPoolAddressesProvider(addressProvider_);
+    wethGateway = IWETHGateway(wethGateway_);
+
+    underlyingToken = IERC721Upgradeable(underlyingToken_);
+    wrappedToken = IERC721Wrapper(wrappedToken_);
+
+    underlyingToken.setApprovalForAll(address(wrappedToken), true);
+
+    wrappedToken.setApprovalForAll(address(_getLendPool()), true);
+    wrappedToken.setApprovalForAll(address(wethGateway), true);
+  }
+
+  function _getLendPool() internal view returns (ILendPool) {
+    return ILendPool(addressProvider.getLendPool());
+  }
+
+  function _getLendPoolLoan() internal view returns (ILendPoolLoan) {
+    return ILendPoolLoan(addressProvider.getLendPoolLoan());
+  }
+
+  function authorizeLendPoolERC20(address[] calldata tokens) external nonReentrant onlyOwner {
+    for (uint256 i = 0; i < tokens.length; i++) {
+      IERC20Upgradeable(tokens[i]).approve(address(_getLendPool()), type(uint256).max);
+    }
+  }
+
+  function authorizeCallerWhitelist(address[] calldata callers, bool flag) external nonReentrant onlyOwner {
+    for (uint256 i = 0; i < callers.length; i++) {
+      _callerWhitelists[callers[i]] = flag;
+    }
+  }
+
+  function isCallerInWhitelist(address caller) external view returns (bool) {
+    return _callerWhitelists[caller];
+  }
+
+  function _checkValidCallerAndOnBehalfOf(address onBehalfOf) internal view {
+    require(
+      (onBehalfOf == _msgSender()) || (_callerWhitelists[_msgSender()] == true),
+      Errors.CALLER_NOT_ONBEHALFOF_OR_IN_WHITELIST
+    );
+  }
+
+  function _depositUnderlyingToken(uint256 nftTokenId) internal {
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    if (loanId != 0) {
+      return;
+    }
+
+    underlyingToken.safeTransferFrom(msg.sender, address(this), nftTokenId);
+
+    wrappedToken.mint(nftTokenId);
+  }
+
+  function borrow(
+    address reserveAsset,
+    uint256 amount,
+    uint256 nftTokenId,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external override nonReentrant {
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    ILendPool cachedPool = _getLendPool();
+
+    _depositUnderlyingToken(nftTokenId);
+
+    cachedPool.borrow(reserveAsset, amount, address(wrappedToken), nftTokenId, onBehalfOf, referralCode);
+
+    IERC20Upgradeable(reserveAsset).transfer(onBehalfOf, amount);
+  }
+
+  function batchBorrow(
+    address[] calldata reserveAssets,
+    uint256[] calldata amounts,
+    uint256[] calldata nftTokenIds,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external override nonReentrant {
+    require(nftTokenIds.length == reserveAssets.length, "WrapperGateway: inconsistent reserveAssets length");
+    require(nftTokenIds.length == amounts.length, "WrapperGateway: inconsistent amounts length");
+
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    ILendPool cachedPool = _getLendPool();
+
+    for (uint256 i = 0; i < nftTokenIds.length; i++) {
+      _depositUnderlyingToken(nftTokenIds[i]);
+
+      cachedPool.borrow(reserveAssets[i], amounts[i], address(wrappedToken), nftTokenIds[i], onBehalfOf, referralCode);
+
+      IERC20Upgradeable(reserveAssets[i]).transfer(onBehalfOf, amounts[i]);
+    }
+  }
+
+  function _withdrawUnderlyingToken(uint256 nftTokenId, address onBehalfOf) internal {
+    address owner = wrappedToken.ownerOf(nftTokenId);
+    require(owner == _msgSender(), "WrapperGateway: caller is not owner");
+    require(owner == onBehalfOf, "WrapperGateway: onBehalfOf is not owner");
+
+    wrappedToken.safeTransferFrom(onBehalfOf, address(this), nftTokenId);
+    wrappedToken.burn(nftTokenId);
+
+    underlyingToken.safeTransferFrom(address(this), owner, nftTokenId);
+  }
+
+  function repay(uint256 nftTokenId, uint256 amount) external override nonReentrant returns (uint256, bool) {
+    return _repay(nftTokenId, amount);
+  }
+
+  function batchRepay(uint256[] calldata nftTokenIds, uint256[] calldata amounts)
+    external
+    override
+    nonReentrant
+    returns (uint256[] memory, bool[] memory)
+  {
+    require(nftTokenIds.length == amounts.length, "WrapperGateway: inconsistent amounts length");
+
+    uint256[] memory repayAmounts = new uint256[](nftTokenIds.length);
+    bool[] memory repayAlls = new bool[](nftTokenIds.length);
+
+    for (uint256 i = 0; i < nftTokenIds.length; i++) {
+      (repayAmounts[i], repayAlls[i]) = _repay(nftTokenIds[i], amounts[i]);
+    }
+
+    return (repayAmounts, repayAlls);
+  }
+
+  function _repay(uint256 nftTokenId, uint256 amount) internal returns (uint256, bool) {
+    ILendPool cachedPool = _getLendPool();
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+    (, , address reserve, ) = cachedPoolLoan.getLoanCollateralAndReserve(loanId);
+    (, uint256 debt) = cachedPoolLoan.getLoanReserveBorrowAmount(loanId);
+    address borrower = cachedPoolLoan.borrowerOf(loanId);
+
+    if (amount > debt) {
+      amount = debt;
+    }
+
+    IERC20Upgradeable(reserve).transferFrom(msg.sender, address(this), amount);
+
+    (uint256 paybackAmount, bool burn) = cachedPool.repay(address(wrappedToken), nftTokenId, amount);
+
+    if (burn) {
+      require(borrower == _msgSender(), "WrapperGateway: caller is not borrower");
+      _withdrawUnderlyingToken(nftTokenId, borrower);
+    }
+
+    return (paybackAmount, burn);
+  }
+
+  function auction(
+    uint256 nftTokenId,
+    uint256 bidPrice,
+    address onBehalfOf
+  ) external override nonReentrant {
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    ILendPool cachedPool = _getLendPool();
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    (, , address reserve, ) = cachedPoolLoan.getLoanCollateralAndReserve(loanId);
+
+    IERC20Upgradeable(reserve).transferFrom(msg.sender, address(this), bidPrice);
+
+    cachedPool.auction(address(wrappedToken), nftTokenId, bidPrice, onBehalfOf);
+  }
+
+  function redeem(
+    uint256 nftTokenId,
+    uint256 amount,
+    uint256 bidFine
+  ) external override nonReentrant returns (uint256) {
+    ILendPool cachedPool = _getLendPool();
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    DataTypes.LoanData memory loan = cachedPoolLoan.getLoan(loanId);
+
+    IERC20Upgradeable(loan.reserveAsset).transferFrom(msg.sender, address(this), (amount + bidFine));
+
+    uint256 paybackAmount = cachedPool.redeem(address(wrappedToken), nftTokenId, amount, bidFine);
+
+    if ((amount + bidFine) > paybackAmount) {
+      IERC20Upgradeable(loan.reserveAsset).safeTransfer(msg.sender, ((amount + bidFine) - paybackAmount));
+    }
+
+    return paybackAmount;
+  }
+
+  function liquidate(uint256 nftTokenId, uint256 amount) external override nonReentrant returns (uint256) {
+    ILendPool cachedPool = _getLendPool();
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    DataTypes.LoanData memory loan = cachedPoolLoan.getLoan(loanId);
+    require(loan.bidderAddress == _msgSender(), "WrapperGateway: caller is not bidder");
+
+    if (amount > 0) {
+      IERC20Upgradeable(loan.reserveAsset).transferFrom(msg.sender, address(this), amount);
+    }
+
+    uint256 extraRetAmount = cachedPool.liquidate(address(wrappedToken), nftTokenId, amount);
+
+    _withdrawUnderlyingToken(nftTokenId, loan.bidderAddress);
+
+    if (amount > extraRetAmount) {
+      IERC20Upgradeable(loan.reserveAsset).safeTransfer(msg.sender, (amount - extraRetAmount));
+    }
+
+    return (extraRetAmount);
+  }
+
+  function borrowETH(
+    uint256 amount,
+    uint256 nftTokenId,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external override nonReentrant {
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    _depositUnderlyingToken(nftTokenId);
+
+    wethGateway.borrowETH(amount, address(wrappedToken), nftTokenId, onBehalfOf, referralCode);
+  }
+
+  function batchBorrowETH(
+    uint256[] calldata amounts,
+    uint256[] calldata nftTokenIds,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external override nonReentrant {
+    require(nftTokenIds.length == amounts.length, "inconsistent amounts length");
+
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    address[] memory nftAssets = new address[](nftTokenIds.length);
+    for (uint256 i = 0; i < nftTokenIds.length; i++) {
+      nftAssets[i] = address(wrappedToken);
+      _depositUnderlyingToken(nftTokenIds[i]);
+    }
+
+    wethGateway.batchBorrowETH(amounts, nftAssets, nftTokenIds, onBehalfOf, referralCode);
+  }
+
+  function repayETH(uint256 nftTokenId, uint256 amount) external payable override nonReentrant returns (uint256, bool) {
+    (uint256 paybackAmount, bool burn) = _repayETH(nftTokenId, amount, 0);
+
+    // refund remaining dust eth
+    if (msg.value > paybackAmount) {
+      _safeTransferETH(msg.sender, msg.value - paybackAmount);
+    }
+
+    return (paybackAmount, burn);
+  }
+
+  function batchRepayETH(uint256[] calldata nftTokenIds, uint256[] calldata amounts)
+    external
+    payable
+    override
+    nonReentrant
+    returns (uint256[] memory, bool[] memory)
+  {
+    require(nftTokenIds.length == amounts.length, "inconsistent amounts length");
+
+    uint256[] memory repayAmounts = new uint256[](nftTokenIds.length);
+    bool[] memory repayAlls = new bool[](nftTokenIds.length);
+    uint256 allRepayAmount = 0;
+
+    for (uint256 i = 0; i < nftTokenIds.length; i++) {
+      (repayAmounts[i], repayAlls[i]) = _repayETH(nftTokenIds[i], amounts[i], allRepayAmount);
+      allRepayAmount += repayAmounts[i];
+    }
+
+    // refund remaining dust eth
+    if (msg.value > allRepayAmount) {
+      _safeTransferETH(msg.sender, msg.value - allRepayAmount);
+    }
+
+    return (repayAmounts, repayAlls);
+  }
+
+  function _repayETH(
+    uint256 nftTokenId,
+    uint256 amount,
+    uint256 accAmount
+  ) internal returns (uint256, bool) {
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    address borrower = cachedPoolLoan.borrowerOf(loanId);
+    require(borrower == _msgSender(), "WrapperGateway: caller is not borrower");
+
+    (, uint256 repayDebtAmount) = cachedPoolLoan.getLoanReserveBorrowAmount(loanId);
+    if (amount < repayDebtAmount) {
+      repayDebtAmount = amount;
+    }
+
+    require(msg.value >= (accAmount + repayDebtAmount), "msg.value is less than repay amount");
+
+    (uint256 paybackAmount, bool burn) = wethGateway.repayETH{value: repayDebtAmount}(
+      address(wrappedToken),
+      nftTokenId,
+      amount
+    );
+
+    if (burn) {
+      _withdrawUnderlyingToken(nftTokenId, borrower);
+    }
+
+    return (paybackAmount, burn);
+  }
+
+  function auctionETH(uint256 nftTokenId, address onBehalfOf) external payable override nonReentrant {
+    _checkValidCallerAndOnBehalfOf(onBehalfOf);
+
+    wethGateway.auctionETH{value: msg.value}(address(wrappedToken), nftTokenId, onBehalfOf);
+  }
+
+  function redeemETH(
+    uint256 nftTokenId,
+    uint256 amount,
+    uint256 bidFine
+  ) external payable override nonReentrant returns (uint256) {
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    //DataTypes.LoanData memory loan = cachedPoolLoan.getLoan(loanId);
+
+    uint256 paybackAmount = wethGateway.redeemETH{value: msg.value}(address(wrappedToken), nftTokenId, amount, bidFine);
+
+    // refund remaining dust eth
+    if (msg.value > paybackAmount) {
+      _safeTransferETH(msg.sender, msg.value - paybackAmount);
+    }
+
+    return paybackAmount;
+  }
+
+  function liquidateETH(uint256 nftTokenId) external payable override nonReentrant returns (uint256) {
+    ILendPoolLoan cachedPoolLoan = _getLendPoolLoan();
+
+    uint256 loanId = cachedPoolLoan.getCollateralLoanId(address(wrappedToken), nftTokenId);
+    require(loanId != 0, "WrapperGateway: no loan with such nftTokenId");
+
+    DataTypes.LoanData memory loan = cachedPoolLoan.getLoan(loanId);
+    require(loan.bidderAddress == _msgSender(), "WrapperGateway: caller is not bidder");
+
+    uint256 extraAmount = wethGateway.liquidateETH{value: msg.value}(address(wrappedToken), nftTokenId);
+
+    _withdrawUnderlyingToken(nftTokenId, loan.bidderAddress);
+
+    // refund remaining dust eth
+    if (msg.value > extraAmount) {
+      _safeTransferETH(msg.sender, msg.value - extraAmount);
+    }
+
+    return extraAmount;
+  }
+
+  /**
+   * @dev transfer ETH to an address, revert if it fails.
+   * @param to recipient of the transfer
+   * @param value the amount to send
+   */
+  function _safeTransferETH(address to, uint256 value) internal {
+    (bool success, ) = to.call{value: value}(new bytes(0));
+    require(success, "ETH_TRANSFER_FAILED");
+  }
+
+  /**
+   * @dev
+   */
+  receive() external payable {}
+
+  /**
+   * @dev Revert fallback calls
+   */
+  fallback() external payable {
+    revert("Fallback not allowed");
+  }
+}

--- a/deployments/deployed-contracts-goerli.json
+++ b/deployments/deployed-contracts-goerli.json
@@ -5,6 +5,10 @@
   "BendProxyAdminFund": {
     "address": "0xd9E1e945e042fa29cD984cb0f280ae5Ce990D993"
   },
+  "BendProxyAdminWTL": {
+    "address": "0x1055d0961CE2E1aF92f57b208171B90f8f1c7916",
+    "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
+  },
   "BendCollectorImpl": {
     "address": "0xE8e43e27b32642F3FD44F9d46239fE157Ef160E7"
   },
@@ -127,6 +131,13 @@
   },
   "MockLoanRepaidInterceptor": {
     "address": "0xA3E10e91fEA0901C2d216B80a9E8C087aB85DECa",
+    "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
+  },
+  "KodaGatewayImpl": {
+    "address": "0xA7bb6431BF998D4e3380ed73DcB226e23E37AA27"
+  },
+  "KodaGateway": {
+    "address": "0x3fa746EcDC1C53c7657a57c71bFaB497be2e0BF5",
     "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
   }
 }

--- a/deployments/deployed-contracts-main.json
+++ b/deployments/deployed-contracts-main.json
@@ -123,5 +123,16 @@
   "UIPoolDataProvider": {
     "address": "0x132E3E3eC6652299B235A26D601aa9C68806e3FE",
     "deployer": "0x868964fa49a6fd6e116FE82c8f4165904406f479"
+  },
+  "BendProxyAdminWTL": {
+    "address": "0x489097c238e2021C00E071479AED1655417bAc34",
+    "deployer": "0x868964fa49a6fd6e116FE82c8f4165904406f479"
+  },
+  "KodaGatewayImpl": {
+    "address": "0x3837Ddc0b0Ee70aA9007dB6bED3f40b9cAEbd202"
+  },
+  "KodaGateway": {
+    "address": "0x56ECe8EDba529943b9A8ED966253b1F5ac54BF55",
+    "deployer": "0x868964fa49a6fd6e116FE82c8f4165904406f479"
   }
 }

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -55,6 +55,7 @@ export const MOCK_NFT_AGGREGATORS_PRICES = {
   MAYC: oneEther.multipliedBy("6.23").toFixed(),
   CLONEX: oneEther.multipliedBy("11.95").toFixed(),
   AZUKI: oneEther.multipliedBy("10.50").toFixed(),
+  WKODA: oneEther.multipliedBy("17.00").toFixed(),
 };
 
 export const MOCK_NFT_BASE_URIS = {
@@ -68,4 +69,5 @@ export const MOCK_NFT_BASE_URIS = {
   CLONEX: "https://clonex-assets.rtfkt.com/",
   AZUKI: "https://ikzttp.mypinata.cloud/ipfs/QmQFkLSQysj94s5GvTHPyzTxrawwtjgiiYS2TBLgrvw8CW/",
   KONGZ: "https://kongz.herokuapp.com/api/metadata/",
+  WKODA: "https://api.otherside.xyz/lands/",
 };

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -38,6 +38,9 @@ import {
   SupplyLogicFactory,
   LiquidateLogic,
   LiquidateLogicFactory,
+  MockerERC721WrapperFactory,
+  MintableERC721,
+  WrapperGatewayFactory,
 } from "../types";
 import { IERC20DetailedFactory } from "../types/IERC20DetailedFactory";
 import { IERC721DetailedFactory } from "../types/IERC721DetailedFactory";
@@ -448,5 +451,23 @@ export const getBendCollectorProxy = async (address?: tEthereumAddress) =>
 export const getBendCollectorImpl = async (address?: tEthereumAddress) =>
   await BendCollectorFactory.connect(
     address || (await getDb(DRE.network.name).get(`${eContractid.BendCollectorImpl}`).value()).address,
+    await getDeploySigner()
+  );
+
+export const getMockERC721Underlying = async (id: string, address?: tEthereumAddress) =>
+  await MintableERC721Factory.connect(
+    address || (await getDb(DRE.network.name).get(`${id}`).value()).address,
+    await getDeploySigner()
+  );
+
+export const getMockERC721Wrapper = async (id: string, address?: tEthereumAddress) =>
+  await MockerERC721WrapperFactory.connect(
+    address || (await getDb(DRE.network.name).get(`${id}`).value()).address,
+    await getDeploySigner()
+  );
+
+export const getWrapperGateway = async (id: string, address?: tEthereumAddress) =>
+  await WrapperGatewayFactory.connect(
+    address || (await getDb(DRE.network.name).get(`${id}`).value()).address,
     await getDeploySigner()
   );

--- a/helpers/contracts-helpers.ts
+++ b/helpers/contracts-helpers.ts
@@ -292,7 +292,11 @@ export const verifyContract = async (id: string, instance: Contract, args: (stri
       args,
       "contracts/libraries/proxy/BendUpgradeableProxy.sol:BendUpgradeableProxy"
     );
-  } else if (id == eContractid.BendProxyAdminFund || id == eContractid.BendProxyAdminPool) {
+  } else if (
+    id == eContractid.BendProxyAdminFund ||
+    id == eContractid.BendProxyAdminPool ||
+    id == eContractid.BendProxyAdminWTL
+  ) {
     await verifyEtherscanContract(
       instance.address,
       args,

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -49,6 +49,7 @@ export enum eContractid {
   BendProxyAdminTest = "BendProxyAdminTest",
   BendProxyAdminPool = "BendProxyAdminPool", //LendPool Contracts, etc Oracle(Reserve, NFT)
   BendProxyAdminFund = "BendProxyAdminFund", //Treasury Fundings, etc Collector
+  BendProxyAdminWTL = "BendProxyAdminWTL", //Common Proxy Admin Without Timelock
   WalletBalanceProvider = "WalletBalanceProvider",
   BToken = "BToken",
   DebtToken = "DebtToken",
@@ -268,6 +269,7 @@ export interface iNftBase<T> {
   MAYC: T;
   CLONEX: T;
   AZUKI: T;
+  WKODA: T;
 }
 
 export type iMultiPoolsNfts<T> = iNftCommon<T> | iBendPoolNfts<T>;
@@ -284,6 +286,7 @@ export enum NftContractId {
   MAYC = "MAYC",
   CLONEX = "CLONEX",
   AZUKI = "AZUKI",
+  WKODA = "WKODA",
 }
 
 export interface IReserveParams extends IReserveBorrowParams, IReserveCollateralParams {
@@ -384,6 +387,7 @@ export interface ICommonConfiguration {
 
   ProxyAdminPool: iParamsPerNetwork<tEthereumAddress | undefined>;
   ProxyAdminFund: iParamsPerNetwork<tEthereumAddress | undefined>;
+  ProxyAdminWTL: iParamsPerNetwork<tEthereumAddress | undefined>;
 
   BNFTRegistry: iParamsPerNetwork<tEthereumAddress | undefined>;
 

--- a/markets/bend/commons.ts
+++ b/markets/bend/commons.ts
@@ -65,6 +65,14 @@ export const CommonsConfig: ICommonConfiguration = {
     [eEthereumNetwork.rinkeby]: '0x64DA9D7651CA78caAB756740C6057e2b7B1E63De',
     [eEthereumNetwork.main]: '0x2A71a0F5cef1fFc519027AD12f19453110e70666',
   },
+  ProxyAdminWTL: {
+    [eEthereumNetwork.coverage]: undefined,
+    [eEthereumNetwork.hardhat]: undefined,
+    [eEthereumNetwork.localhost]: undefined,
+    [eEthereumNetwork.goerli]: "0x1055d0961CE2E1aF92f57b208171B90f8f1c7916",
+    [eEthereumNetwork.rinkeby]: undefined,
+    [eEthereumNetwork.main]: undefined,
+  },
 
   // If PoolAdmin/emergencyAdmin is set, will take priority over PoolAdminIndex/emergencyAdminIndex
   PoolAdmin: {

--- a/markets/bend/index.ts
+++ b/markets/bend/index.ts
@@ -16,6 +16,7 @@ import {
   strategyNft_KONGZ,
   strategyNft_MAYC,
   strategyNft_MEEBITS,
+  strategyNft_WKODA,
   strategyNft_WOW,
   strategyNft_WPUNKS,
 } from './nftsConfigs';
@@ -41,6 +42,7 @@ export const BendConfig: IBendConfiguration = {
     MAYC: strategyNft_MAYC,
     CLONEX: strategyNft_CLONEX,
     AZUKI: strategyNft_AZUKI,
+    WKODA: strategyNft_WKODA,
   },
   ReserveAssets: {
     [eEthereumNetwork.hardhat]: {},

--- a/markets/bend/nftsConfigs.ts
+++ b/markets/bend/nftsConfigs.ts
@@ -130,6 +130,12 @@ export const strategyNft_WOW: INftParams = {
   maxTokenId: "9999",
 };
 
+export const strategyNft_WKODA: INftParams = {
+  ...strategyNftClassB,
+  maxSupply: "10000",
+  maxTokenId: "99999",
+};
+
 export const strategyNftParams: SymbolMap<INftParams> = {
   "ClassA": strategyNftClassA,
   "ClassB": strategyNftClassB,
@@ -147,4 +153,5 @@ export const strategyNftParams: SymbolMap<INftParams> = {
   "COOL": strategyNft_COOL,
   "MEEBITS": strategyNft_MEEBITS,
   "WOW": strategyNft_WOW,
+  "WKODA": strategyNft_WKODA,
 };

--- a/scripts/updateAbis.js
+++ b/scripts/updateAbis.js
@@ -14,6 +14,7 @@ const protocolContractList = [
   "DebtToken",
   "PunkGateway",
   "WETHGateway",
+  "WrapperGateway",
 ];
 
 const miscContractList = ["UiPoolDataProvider", "BendProtocolDataProvider", "WalletBalanceProvider"];

--- a/tasks/full/proxy-admin.ts
+++ b/tasks/full/proxy-admin.ts
@@ -10,16 +10,16 @@ import { BendProxyAdmin } from "../../types";
 task("full:deploy-proxy-admin", "Deploy proxy admin contract")
   .addFlag("verify", "Verify contracts at Etherscan")
   .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
-  .addFlag("skipPool", "Skip proxy admin for POOL")
-  .addFlag("skipFund", "Skip proxy admin for FUND")
-  .setAction(async ({ verify, pool, skipPool, skipFund }, DRE) => {
+  .addFlag("all", "Create all proxy admin")
+  .addParam("proxyadminid", "Proxy admin ID")
+  .setAction(async ({ verify, pool, all, proxyadminid }, DRE) => {
     await DRE.run("set-DRE");
     await DRE.run("compile");
 
     const poolConfig = loadPoolConfig(pool);
     const network = <eNetwork>DRE.network.name;
 
-    if (!skipPool) {
+    if (all || proxyadminid == eContractid.BendProxyAdminPool) {
       let proxyAdmin: BendProxyAdmin;
       const proxyAdminAddress = getParamPerNetwork(poolConfig.ProxyAdminPool, network);
       if (proxyAdminAddress == undefined || !notFalsyOrZeroAddress(proxyAdminAddress)) {
@@ -28,10 +28,10 @@ task("full:deploy-proxy-admin", "Deploy proxy admin contract")
         await insertContractAddressInDb(eContractid.BendProxyAdminPool, proxyAdminAddress);
         proxyAdmin = await getBendProxyAdminByAddress(proxyAdminAddress);
       }
-      console.log("ProxyAdminPool Address:", proxyAdmin.address, "Owner Address:", await proxyAdmin.owner());
+      console.log("BendProxyAdminPool Address:", proxyAdmin.address, "Owner Address:", await proxyAdmin.owner());
     }
 
-    if (!skipFund) {
+    if (all || proxyadminid == eContractid.BendProxyAdminFund) {
       let proxyAdmin: BendProxyAdmin;
       const proxyAdminAddress = getParamPerNetwork(poolConfig.ProxyAdminFund, network);
       if (proxyAdminAddress == undefined || !notFalsyOrZeroAddress(proxyAdminAddress)) {
@@ -41,5 +41,17 @@ task("full:deploy-proxy-admin", "Deploy proxy admin contract")
         proxyAdmin = await getBendProxyAdminByAddress(proxyAdminAddress);
       }
       console.log("BendProxyAdminFund Address:", proxyAdmin.address, "Owner Address:", await proxyAdmin.owner());
+    }
+
+    if (all || proxyadminid == eContractid.BendProxyAdminWTL) {
+      let proxyAdmin: BendProxyAdmin;
+      const proxyAdminAddress = getParamPerNetwork(poolConfig.ProxyAdminWTL, network);
+      if (proxyAdminAddress == undefined || !notFalsyOrZeroAddress(proxyAdminAddress)) {
+        proxyAdmin = await deployBendProxyAdmin(eContractid.BendProxyAdminWTL, verify);
+      } else {
+        await insertContractAddressInDb(eContractid.BendProxyAdminWTL, proxyAdminAddress);
+        proxyAdmin = await getBendProxyAdminByAddress(proxyAdminAddress);
+      }
+      console.log("BendProxyAdminWTL Address:", proxyAdmin.address, "Owner Address:", await proxyAdmin.owner());
     }
   });

--- a/tasks/full/wrapper-gateway.ts
+++ b/tasks/full/wrapper-gateway.ts
@@ -1,0 +1,106 @@
+import { task } from "hardhat/config";
+import { loadPoolConfig, ConfigNames } from "../../helpers/configuration";
+import { deployBendUpgradeableProxy, deployWrapperGateway } from "../../helpers/contracts-deployments";
+import {
+  getBendProxyAdminById,
+  getBendUpgradeableProxy,
+  getLendPoolAddressesProvider,
+  getWETHGateway,
+  getWrapperGateway,
+} from "../../helpers/contracts-getters";
+import { insertContractAddressInDb } from "../../helpers/contracts-helpers";
+import { notFalsyOrZeroAddress, waitForTx } from "../../helpers/misc-utils";
+import { eContractid, eNetwork } from "../../helpers/types";
+import { BendUpgradeableProxy, WrapperGateway } from "../../types";
+
+task(`full:deploy-wrapper-gateway`, `Deploys the WrapperGateway contract`)
+  .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
+  .addFlag("verify", `Verify contract via Etherscan API.`)
+  .addParam("gatewayid", "The wrapper gateway id")
+  .addParam("underlying", "The underlying token address")
+  .addParam("wrapper", "The wrapper token address")
+  .setAction(async ({ verify, pool, gatewayid, underlying, wrapper }, DRE) => {
+    await DRE.run("set-DRE");
+    await DRE.run("compile");
+
+    if (!DRE.network.config.chainId) {
+      throw new Error("INVALID_CHAIN_ID");
+    }
+
+    const poolConfig = loadPoolConfig(pool);
+    const addressesProvider = await getLendPoolAddressesProvider();
+
+    const proxyAdmin = await getBendProxyAdminById(eContractid.BendProxyAdminWTL);
+    if (proxyAdmin == undefined || !notFalsyOrZeroAddress(proxyAdmin.address)) {
+      throw Error("Invalid common proxy admin in config");
+    }
+    const proxyAdminOwnerAddress = await proxyAdmin.owner();
+    const proxyAdminOwnerSigner = DRE.ethers.provider.getSigner(proxyAdminOwnerAddress);
+
+    const wethGateWay = await getWETHGateway();
+    console.log("wethGateWay.address", wethGateWay.address);
+    console.log("underlying.address", underlying);
+    console.log("wrapper.address", wrapper);
+
+    // this contract is not support upgrade, just deploy new contract
+    console.log(`Deploying new ${gatewayid} implementation...`);
+    const wrapperGateWayImpl = await deployWrapperGateway(gatewayid, verify);
+    const initEncodedData = wrapperGateWayImpl.interface.encodeFunctionData("initialize", [
+      addressesProvider.address,
+      wethGateWay.address,
+      underlying,
+      wrapper,
+    ]);
+
+    let wrapperGateWay: WrapperGateway;
+    let wrapperGatewayProxy: BendUpgradeableProxy;
+
+    const wrapperGatewayAddress = undefined; //await addressesProvider.getAddress(ADDRESS_ID_XXX_GATEWAY);
+
+    if (wrapperGatewayAddress != undefined && notFalsyOrZeroAddress(wrapperGatewayAddress)) {
+      console.log(`Upgrading exist ${gatewayid} proxy to new implementation...`);
+
+      await insertContractAddressInDb(gatewayid, wrapperGatewayAddress);
+      wrapperGatewayProxy = await getBendUpgradeableProxy(wrapperGatewayAddress);
+
+      // only proxy admin can do upgrading
+      await waitForTx(
+        await proxyAdmin.connect(proxyAdminOwnerSigner).upgrade(wrapperGatewayProxy.address, wrapperGateWayImpl.address)
+      );
+
+      wrapperGateWay = await getWrapperGateway(gatewayid, wrapperGatewayProxy.address);
+    } else {
+      console.log(`Deploying new ${gatewayid} proxy with implementation...`);
+      const wrapperGatewayProxy = await deployBendUpgradeableProxy(
+        gatewayid,
+        proxyAdmin.address,
+        wrapperGateWayImpl.address,
+        initEncodedData,
+        verify
+      );
+
+      wrapperGateWay = await getWrapperGateway(gatewayid, wrapperGatewayProxy.address);
+    }
+
+    //await waitForTx(await addressesProvider.setAddress(ADDRESS_ID_XXX_GATEWAY, wrapperGateWay.address));
+
+    console.log(`${gatewayid}: proxy ${wrapperGateWay.address}, implementation ${wrapperGateWayImpl.address}`);
+
+    console.log(`Finished ${gatewayid} deployment`);
+  });
+
+task("full:wrapper-authorize-caller-whitelist", "Initialize gateway configuration.")
+  .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
+  .addParam("id", "The wrapper gateway id")
+  .addParam("caller", "Address of whitelist")
+  .addParam("flag", "Flag of whitelist, 0-1")
+  .setAction(async ({ pool, id, caller, flag }, localBRE) => {
+    await localBRE.run("set-DRE");
+    const network = <eNetwork>localBRE.network.name;
+    const poolConfig = loadPoolConfig(pool);
+
+    const wrapperGateWay = await getWrapperGateway(id);
+
+    console.log(`${id}: ${wrapperGateWay.address}`);
+    await waitForTx(await wrapperGateWay.authorizeCallerWhitelist([caller], flag));
+  });

--- a/tasks/migrations/bend.dev.ts
+++ b/tasks/migrations/bend.dev.ts
@@ -33,7 +33,7 @@ task("bend:dev", "Deploy development enviroment")
 
     //////////////////////////////////////////////////////////////////////////
     console.log("\n\nDeploy proxy admin");
-    await localBRE.run("full:deploy-proxy-admin", { verify, pool: POOL_NAME });
+    await localBRE.run("full:deploy-proxy-admin", { verify, pool: POOL_NAME, all: true });
 
     //////////////////////////////////////////////////////////////////////////
     console.log("\n\nDeploy address provider");

--- a/tasks/migrations/bend.mainnet.ts
+++ b/tasks/migrations/bend.mainnet.ts
@@ -50,7 +50,7 @@ task("bend:mainnet", "Deploy full enviroment")
 
     //////////////////////////////////////////////////////////////////////////
     console.log("\n\nDeploy proxy admin");
-    await DRE.run("full:deploy-proxy-admin", { pool: POOL_NAME });
+    await DRE.run("full:deploy-proxy-admin", { pool: POOL_NAME, all: true });
 
     //////////////////////////////////////////////////////////////////////////
     console.log("\n\nDeploy bend collector");

--- a/tasks/verifications/gateway.ts
+++ b/tasks/verifications/gateway.ts
@@ -1,0 +1,42 @@
+import { task } from "hardhat/config";
+import { loadPoolConfig, ConfigNames } from "../../helpers/configuration";
+import { getBendProxyAdminById, getWrapperGateway } from "../../helpers/contracts-getters";
+import { getParamPerNetwork, verifyContract } from "../../helpers/contracts-helpers";
+import { eContractid, eNetwork } from "../../helpers/types";
+
+task("verify:WrapperGateway", "Verify WrapperGateway contracts at Etherscan")
+  .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
+  .addParam("gatewayid", "The wrapper gateway id")
+  .setAction(async ({ gatewayid, pool }, localDRE) => {
+    await localDRE.run("set-DRE");
+    const network = localDRE.network.name as eNetwork;
+    const poolConfig = loadPoolConfig(pool);
+
+    const proxyAdminWTL = await getBendProxyAdminById(eContractid.BendProxyAdminWTL);
+
+    // Impl
+    console.log(`\n- Verifying ${gatewayid} Impl...\n`);
+    const implId = gatewayid + "Impl";
+    const gatewayImpl = await getWrapperGateway(implId);
+    console.log(`gatewayImpl: ${gatewayImpl.address}`);
+    await verifyContract(implId, gatewayImpl, []);
+
+    // Proxy
+    console.log(`\n- Verifying ${gatewayid} Proxy...\n`);
+    const gatewayProxy = await getWrapperGateway(gatewayid);
+    console.log(`gatewayProxy: ${gatewayProxy.address}`);
+    const addressesProvider = await gatewayProxy.addressProvider();
+    const wethGateway = await gatewayProxy.wethGateway();
+    const underlying = await gatewayProxy.underlying();
+    const wrappedToken = await gatewayProxy.wrappedToken();
+    await verifyContract(eContractid.BendUpgradeableProxy, gatewayProxy, [
+      gatewayImpl.address,
+      proxyAdminWTL.address,
+      gatewayImpl.interface.encodeFunctionData("initialize", [
+        addressesProvider,
+        wethGateway,
+        underlying,
+        wrappedToken,
+      ]),
+    ]);
+  });

--- a/tasks/verifications/general.ts
+++ b/tasks/verifications/general.ts
@@ -75,6 +75,9 @@ task("verify:general", "Verify general contracts at Etherscan")
     const proxyAdminPool = await getBendProxyAdminById(eContractid.BendProxyAdminPool);
     await verifyContract(eContractid.BendProxyAdminPool, proxyAdminPool, []);
 
+    const proxyAdminWTL = await getBendProxyAdminById(eContractid.BendProxyAdminWTL);
+    await verifyContract(eContractid.BendProxyAdminWTL, proxyAdminWTL, []);
+
     if (all) {
       const dataProvider = await getBendProtocolDataProvider();
       const walletProvider = await getWalletProvider();

--- a/test/helpers/actions.ts
+++ b/test/helpers/actions.ts
@@ -157,6 +157,15 @@ export const approveERC20PunkGateway = async (testEnv: TestEnv, user: SignerWith
   await waitForTx(await token.connect(user.signer).approve(punkGateway.address, MAX_UINT_AMOUNT));
 };
 
+export const approveERC20WrapperGateway = async (testEnv: TestEnv, user: SignerWithAddress, reserveSymbol: string) => {
+  const { wrapperGateway } = testEnv;
+  const reserve = await getReserveAddressFromSymbol(reserveSymbol);
+
+  const token = await getMintableERC20(reserve);
+
+  await waitForTx(await token.connect(user.signer).approve(wrapperGateway.address, MAX_UINT_AMOUNT));
+};
+
 export const approveERC721 = async (testEnv: TestEnv, user: SignerWithAddress, nftSymbol: string, tokenId: string) => {
   const { pool } = testEnv;
   const reserve = await getNftAddressFromSymbol(nftSymbol);

--- a/test/helpers/make-suite.ts
+++ b/test/helpers/make-suite.ts
@@ -25,8 +25,11 @@ import {
   getDebtToken,
   getWalletProvider,
   getUIPoolDataProvider,
+  getMockERC721Wrapper,
+  getWrapperGateway,
+  getMockERC721Underlying,
 } from "../../helpers/contracts-getters";
-import { eEthereumNetwork, eNetwork, tEthereumAddress } from "../../helpers/types";
+import { eContractid, eEthereumNetwork, eNetwork, tEthereumAddress } from "../../helpers/types";
 import { LendPool } from "../../types/LendPool";
 import { BendProtocolDataProvider } from "../../types/BendProtocolDataProvider";
 import { MintableERC20 } from "../../types/MintableERC20";
@@ -60,6 +63,8 @@ import {
   MockIncentivesController,
   UiPoolDataProvider,
   WalletBalanceProvider,
+  MockerERC721Wrapper,
+  WrapperGateway,
 } from "../../types";
 import { MockChainlinkOracle } from "../../types/MockChainlinkOracle";
 import { USD_ADDRESS } from "../../helpers/constants";
@@ -107,6 +112,12 @@ export interface TestEnv {
   wrappedPunk: WrappedPunk;
   punkGateway: PunkGateway;
 
+  mockOtherdeed: MintableERC721;
+  landIdTracker: number;
+  wrappedKoda: MockerERC721Wrapper;
+  bWKoda: BNFT;
+  wrapperGateway: WrapperGateway;
+
   roundIdTracker: number;
   nowTimeTracker: number;
 }
@@ -145,6 +156,12 @@ const testEnv: TestEnv = {
   addressesProvider: {} as LendPoolAddressesProvider,
   wethGateway: {} as WETHGateway,
   //wpunksGateway: {} as WPUNKSGateway,
+  mockOtherdeed: {} as MintableERC721,
+  wrappedKoda: {} as MockerERC721Wrapper,
+  bWKoda: {} as BNFT,
+  wrapperGateway: {} as WrapperGateway,
+  punkIndexTracker: {} as number,
+  landIdTracker: {} as number,
   tokenIdTracker: {} as number,
   roundIdTracker: {} as number,
   nowTimeTracker: {} as number,
@@ -220,9 +237,11 @@ export async function initializeMakeSuite() {
   //console.log("allBNftTokens", allBNftTokens);
   const bPunkAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "WPUNKS")?.bNftAddress;
   const bByacAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "BAYC")?.bNftAddress;
+  const bWKodaAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "WKODA")?.bNftAddress;
 
   const wpunksAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "WPUNKS")?.nftAddress;
   const baycAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "BAYC")?.nftAddress;
+  const wkodaAddress = allBNftTokens.find((tokenData) => tokenData.nftSymbol === "WKODA")?.nftAddress;
 
   if (!bByacAddress || !bPunkAddress) {
     console.error("Invalid BNFT Tokens", bByacAddress, bPunkAddress);
@@ -242,8 +261,14 @@ export async function initializeMakeSuite() {
   testEnv.wrappedPunk = await getWrappedPunk();
   testEnv.punkGateway = await getPunkGateway();
 
+  testEnv.mockOtherdeed = await getMockERC721Underlying("MockOtherdeed");
+  testEnv.wrappedKoda = await getMockERC721Wrapper("WKODA", wkodaAddress);
+  testEnv.bWKoda = await getBNFT(bWKodaAddress);
+  testEnv.wrapperGateway = await getWrapperGateway("KodaWrapperGateway");
+
   testEnv.tokenIdTracker = 100;
   testEnv.punkIndexTracker = 0;
+  testEnv.landIdTracker = 0;
 
   testEnv.roundIdTracker = 1;
   testEnv.nowTimeTracker = Number(await getNowTimeInSeconds());

--- a/test/wrappergateway-batch.spec.ts
+++ b/test/wrappergateway-batch.spec.ts
@@ -1,0 +1,229 @@
+import BigNumber from "bignumber.js";
+import { BigNumber as BN } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+import DRE from "hardhat";
+
+import { getReservesConfigByPool } from "../helpers/configuration";
+import { BendPools, iBendPoolAssets, IReserveParams, ProtocolLoanState } from "../helpers/types";
+import {
+  approveERC20,
+  approveERC20WrapperGateway,
+  configuration as actionsConfiguration,
+  deposit,
+  mintERC20,
+} from "./helpers/actions";
+import { makeSuite, TestEnv } from "./helpers/make-suite";
+import { configuration as calculationsConfiguration } from "./helpers/utils/calculations";
+import { convertToCurrencyDecimals } from "../helpers/contracts-helpers";
+import { advanceTimeAndBlock, waitForTx } from "../helpers/misc-utils";
+import { getERC20TokenBalance, getLoanData } from "./helpers/utils/helpers";
+import { getDebtToken } from "../helpers/contracts-getters";
+import { MAX_UINT_AMOUNT } from "../helpers/constants";
+
+const chai = require("chai");
+const { expect } = chai;
+
+makeSuite("WrapperGateway: Batch borrow", (testEnv: TestEnv) => {
+  before("Initializing configuration", async () => {
+    // Sets BigNumber for this suite, instead of globally
+    BigNumber.config({
+      DECIMAL_PLACES: 0,
+      ROUNDING_MODE: BigNumber.ROUND_DOWN,
+    });
+
+    actionsConfiguration.skipIntegrityCheck = false; //set this to true to execute solidity-coverage
+
+    calculationsConfiguration.reservesParams = <iBendPoolAssets<IReserveParams>>(
+      getReservesConfigByPool(BendPools.proto)
+    );
+  });
+  after("Reset", () => {
+    // Reset BigNumber
+    BigNumber.config({
+      DECIMAL_PLACES: 20,
+      ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+    });
+  });
+
+  it("Batch Borrow USDC", async () => {
+    const { users, mockOtherdeed, wrappedKoda, wrapperGateway, wethGateway, pool, dataProvider, usdc } = testEnv;
+
+    const [depositor, borrower] = users;
+    const depositUnit = "10000";
+
+    // Deposit USDC
+    await mintERC20(testEnv, depositor, "USDC", depositUnit.toString());
+    await approveERC20(testEnv, depositor, "USDC");
+    await deposit(testEnv, depositor, "", "USDC", depositUnit.toString(), depositor.address, "success", "");
+
+    const borrowSize1 = await convertToCurrencyDecimals(usdc.address, "1000");
+    const borrowSize2 = await convertToCurrencyDecimals(usdc.address, "2000");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+
+    // Mint NFTs
+    const landId1 = testEnv.landIdTracker++;
+    const landId2 = testEnv.landIdTracker++;
+
+    const getDebtBalance = async (landId: number) => {
+      const loan = await getLoanData(pool, dataProvider, wrappedKoda.address, `${landId}`, "0");
+      return BN.from(loan.currentAmount.toFixed(0));
+    };
+
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId1));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId1));
+
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId2));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId2));
+
+    const usdcBalanceBefore = await getERC20TokenBalance(usdc.address, borrower.address);
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(usdc.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(
+      await debtToken.connect(borrower.signer).approveDelegation(wrapperGateway.address, MAX_UINT_AMOUNT)
+    );
+
+    // Batch borrow usdc
+    console.log("Batch borrow usdc");
+    await waitForTx(
+      await wrapperGateway
+        .connect(borrower.signer)
+        .batchBorrow(
+          [usdc.address, usdc.address],
+          [borrowSize1, borrowSize2],
+          [landId1, landId2],
+          borrower.address,
+          "0"
+        )
+    );
+
+    const usdcBalanceAfterBorrow = await getERC20TokenBalance(usdc.address, borrower.address);
+    expect(usdcBalanceAfterBorrow).to.be.gte(usdcBalanceBefore.add(borrowSizeAll));
+
+    const debt1AfterBorrow = await getDebtBalance(landId1);
+    expect(debt1AfterBorrow).to.be.gte(borrowSize1);
+
+    const debt2AfterBorrow = await getDebtBalance(landId2);
+    expect(debt2AfterBorrow).to.be.gte(borrowSize2);
+
+    await mintERC20(testEnv, borrower, "USDC", depositUnit.toString());
+    await approveERC20WrapperGateway(testEnv, borrower, "USDC");
+    await waitForTx(await wrappedKoda.connect(borrower.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    // Batch repay usdc
+    console.log("Batch repay usdc - partial");
+    await waitForTx(
+      await wrapperGateway
+        .connect(borrower.signer)
+        .batchRepay([landId1, landId2], [borrowSize1.div(2), borrowSize1.div(2)])
+    );
+
+    const loanData1AfterRepayPart = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId1);
+    expect(loanData1AfterRepayPart.state).to.be.eq(ProtocolLoanState.Active);
+
+    const loanData2AfterRepayPart = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId2);
+    expect(loanData2AfterRepayPart.state).to.be.eq(ProtocolLoanState.Active);
+
+    console.log("Batch repay usdc - full");
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).batchRepay([landId1, landId2], [MAX_UINT_AMOUNT, MAX_UINT_AMOUNT])
+    );
+
+    const loanData1AfterRepayFull = await dataProvider.getLoanDataByLoanId(loanData1AfterRepayPart.loanId);
+    expect(loanData1AfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+
+    const loanData2AfterRepayFull = await dataProvider.getLoanDataByLoanId(loanData2AfterRepayPart.loanId);
+    expect(loanData2AfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+  });
+
+  it("Batch Borrow ETH", async () => {
+    const { users, pool, mockOtherdeed, wrappedKoda, wrapperGateway, weth, bWETH, wethGateway, dataProvider } = testEnv;
+
+    const [depositor, borrower] = users;
+    const depositSize = parseEther("10");
+    const borrowSize1 = parseEther("1");
+    const borrowSize2 = parseEther("2");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+    const gasCost = parseEther("0.2");
+
+    // Deposit with native ETH
+    await waitForTx(
+      await wethGateway.connect(depositor.signer).depositETH(depositor.address, "0", { value: depositSize })
+    );
+
+    // mint nfts
+    const landId1 = testEnv.landIdTracker++;
+    const landId2 = testEnv.landIdTracker++;
+
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId1));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId1));
+
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId2));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId2));
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(weth.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(borrower.signer).approveDelegation(wethGateway.address, MAX_UINT_AMOUNT));
+
+    const userBalanceBeforeBorrow = await borrower.signer.getBalance();
+
+    // Batch borrow eth
+    console.log("Batch borrow eth");
+    await waitForTx(
+      await wrapperGateway
+        .connect(borrower.signer)
+        .batchBorrowETH([borrowSize1, borrowSize2], [landId1, landId2], borrower.address, "0")
+    );
+
+    // Check results
+    const userBalanceAfterBorrow = await borrower.signer.getBalance();
+    expect(userBalanceAfterBorrow).to.be.gte(userBalanceBeforeBorrow.add(borrowSizeAll).sub(gasCost));
+
+    const loanData1AfterBorrow = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId1);
+    expect(loanData1AfterBorrow.state).to.be.eq(ProtocolLoanState.Active);
+
+    const loanData2AfterBorrow = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId1);
+    expect(loanData2AfterBorrow.state).to.be.eq(ProtocolLoanState.Active);
+
+    await advanceTimeAndBlock(100);
+
+    await waitForTx(await wrappedKoda.connect(borrower.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    // Batch repay eth
+    console.log("Batch repay eth - partial");
+    const repaySize1Part = borrowSize1.div(2);
+    const repaySize2Part = borrowSize2.div(2);
+    await waitForTx(
+      await wrapperGateway
+        .connect(borrower.signer)
+        .batchRepayETH([landId1, landId2], [borrowSize1.div(2), borrowSize1.div(2)], {
+          value: repaySize1Part.add(repaySize2Part),
+        })
+    );
+
+    const loanData1AfterRepayPart = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId1);
+    expect(loanData1AfterRepayPart.state).to.be.eq(ProtocolLoanState.Active);
+
+    const loanData2AfterRepayPart = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId2);
+    expect(loanData2AfterRepayPart.state).to.be.eq(ProtocolLoanState.Active);
+
+    console.log("Batch repay eth - full");
+    const repaySize1Full = new BigNumber(loanData1AfterRepayPart.currentAmount.toString());
+    const repaySize2Full = new BigNumber(loanData2AfterRepayPart.currentAmount.toString());
+    await waitForTx(
+      await wrapperGateway
+        .connect(borrower.signer)
+        .batchRepayETH([landId1, landId2], [MAX_UINT_AMOUNT, MAX_UINT_AMOUNT], {
+          value: repaySize1Full.plus(repaySize2Full).multipliedBy(1.001).toFixed(0),
+        })
+    );
+
+    const loanData1AfterRepayFull = await dataProvider.getLoanDataByLoanId(loanData1AfterRepayPart.loanId);
+    expect(loanData1AfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+
+    const loanData2AfterRepayFull = await dataProvider.getLoanDataByLoanId(loanData2AfterRepayPart.loanId);
+    expect(loanData2AfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+  });
+});

--- a/test/wrappergateway-delegate.spec.ts
+++ b/test/wrappergateway-delegate.spec.ts
@@ -1,0 +1,86 @@
+import BigNumber from "bignumber.js";
+import { BigNumber as BN } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+import DRE from "hardhat";
+
+import { getReservesConfigByPool } from "../helpers/configuration";
+import { BendPools, iBendPoolAssets, IReserveParams, ProtocolErrors } from "../helpers/types";
+import { configuration as actionsConfiguration } from "./helpers/actions";
+import { makeSuite, TestEnv } from "./helpers/make-suite";
+import { configuration as calculationsConfiguration } from "./helpers/utils/calculations";
+
+const chai = require("chai");
+const { expect } = chai;
+
+makeSuite("WrapperGateway: Delegate", (testEnv: TestEnv) => {
+  const depositSize = parseEther("5");
+
+  before("Initializing configuration", async () => {
+    // Sets BigNumber for this suite, instead of globally
+    BigNumber.config({
+      DECIMAL_PLACES: 0,
+      ROUNDING_MODE: BigNumber.ROUND_DOWN,
+    });
+
+    actionsConfiguration.skipIntegrityCheck = false; //set this to true to execute solidity-coverage
+
+    calculationsConfiguration.reservesParams = <iBendPoolAssets<IReserveParams>>(
+      getReservesConfigByPool(BendPools.proto)
+    );
+  });
+  after("Reset", () => {
+    // Reset BigNumber
+    BigNumber.config({
+      DECIMAL_PLACES: 20,
+      ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+    });
+  });
+
+  it("Hacker try to borrow and delegate different onBehalf (should revert)", async () => {
+    const { users, wrapperGateway, weth } = testEnv;
+    const depositor = users[0];
+    const borrower = users[1];
+    const liquidator = users[2];
+    const hacker = users[3];
+    const borrowSize1 = parseEther("1");
+    const borrowSize2 = parseEther("2");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+
+    const tokenIdNum = testEnv.tokenIdTracker++;
+    const tokenId = tokenIdNum.toString();
+
+    console.log("borrow");
+    await expect(
+      wrapperGateway.connect(hacker.signer).borrow(weth.address, borrowSize2, tokenId, borrower.address, "0")
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_ONBEHALFOF_OR_IN_WHITELIST);
+
+    console.log("borrowETH");
+    await expect(
+      wrapperGateway.connect(hacker.signer).borrowETH(borrowSize2, tokenId, borrower.address, "0")
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_ONBEHALFOF_OR_IN_WHITELIST);
+  });
+
+  it("Hacker try to auction and delegate different onBehalf (should revert)", async () => {
+    const { users, wrapperGateway, weth } = testEnv;
+    const depositor = users[0];
+    const borrower = users[1];
+    const liquidator = users[2];
+    const hacker = users[3];
+    const borrowSize1 = parseEther("1");
+    const borrowSize2 = parseEther("2");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+
+    const tokenIdNum = testEnv.tokenIdTracker++;
+    const tokenId = tokenIdNum.toString();
+
+    console.log("auction");
+    await expect(
+      wrapperGateway.connect(hacker.signer).auction(tokenId, "1000000", liquidator.address)
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_ONBEHALFOF_OR_IN_WHITELIST);
+
+    console.log("auctionETH");
+    await expect(
+      wrapperGateway.connect(hacker.signer).auctionETH(tokenId, liquidator.address, { value: depositSize })
+    ).to.be.revertedWith(ProtocolErrors.CALLER_NOT_ONBEHALFOF_OR_IN_WHITELIST);
+  });
+});

--- a/test/wrappergateway-liquidate.spec.ts
+++ b/test/wrappergateway-liquidate.spec.ts
@@ -1,0 +1,503 @@
+import BigNumber from "bignumber.js";
+import { BigNumber as BN } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+
+import { getReservesConfigByPool } from "../helpers/configuration";
+import { MAX_UINT_AMOUNT, oneEther, ONE_HOUR } from "../helpers/constants";
+import { getDebtToken } from "../helpers/contracts-getters";
+import { convertToCurrencyDecimals, convertToCurrencyUnits } from "../helpers/contracts-helpers";
+import { advanceBlock, advanceTimeAndBlock, increaseTime, sleep, waitForTx } from "../helpers/misc-utils";
+import { BendPools, iBendPoolAssets, IReserveParams, ProtocolLoanState } from "../helpers/types";
+import {
+  approveERC20,
+  approveERC20WrapperGateway,
+  configuration as actionsConfiguration,
+  deposit,
+  mintERC20,
+  setNftAssetPrice,
+  setNftAssetPriceForDebt,
+} from "./helpers/actions";
+import { makeSuite, TestEnv } from "./helpers/make-suite";
+import { configuration as calculationsConfiguration } from "./helpers/utils/calculations";
+
+const chai = require("chai");
+const { expect } = chai;
+
+makeSuite("WrapperGateway-Liquidate", (testEnv: TestEnv) => {
+  const zero = BN.from(0);
+  let kodaInitPrice: BN;
+
+  before("Initializing configuration", async () => {
+    // Sets BigNumber for this suite, instead of globally
+    BigNumber.config({
+      DECIMAL_PLACES: 0,
+      ROUNDING_MODE: BigNumber.ROUND_DOWN,
+    });
+
+    actionsConfiguration.skipIntegrityCheck = false; //set this to true to execute solidity-coverage
+
+    calculationsConfiguration.reservesParams = <iBendPoolAssets<IReserveParams>>(
+      getReservesConfigByPool(BendPools.proto)
+    );
+
+    kodaInitPrice = await testEnv.nftOracle.getAssetPrice(testEnv.wrappedKoda.address);
+  });
+  after("Reset", async () => {
+    // Reset BigNumber
+    BigNumber.config({
+      DECIMAL_PLACES: 20,
+      ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+    });
+
+    await setNftAssetPrice(testEnv, "WKODA", kodaInitPrice.toString());
+  });
+
+  it("Borrow USDC and liquidate it", async () => {
+    const {
+      users,
+      mockOtherdeed,
+      wrappedKoda,
+      wrapperGateway,
+      wethGateway,
+      usdc,
+      pool,
+      dataProvider,
+      reserveOracle,
+      nftOracle,
+    } = testEnv;
+
+    const [depositor, borrower] = users;
+    const liquidator = users[4];
+    const depositUnit = "200000";
+    const depositSize = await convertToCurrencyDecimals(usdc.address, "200000");
+
+    await sleep(1000 * 1);
+    await setNftAssetPrice(testEnv, "WKODA", kodaInitPrice.toString());
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(usdc.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(
+      await debtToken.connect(borrower.signer).approveDelegation(wrapperGateway.address, MAX_UINT_AMOUNT)
+    );
+
+    const landId = testEnv.landIdTracker++;
+
+    const getKodaOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+
+    // Deposit USDC
+    await mintERC20(testEnv, depositor, "USDC", depositUnit.toString());
+    await approveERC20(testEnv, depositor, "USDC");
+    await deposit(testEnv, depositor, "", "USDC", depositUnit.toString(), depositor.address, "success", "");
+
+    await advanceTimeAndBlock(100);
+
+    // mint native nft
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId));
+
+    const nftCfgData = await dataProvider.getNftConfigurationData(wrappedKoda.address);
+
+    await advanceTimeAndBlock(100);
+
+    // borrow usdc, health factor above 1
+    const nftColDataBefore = await pool.getNftCollateralData(wrappedKoda.address, usdc.address);
+
+    const usdcPrice = await reserveOracle.getAssetPrice(usdc.address);
+    const amountBorrow = await convertToCurrencyDecimals(
+      usdc.address,
+      new BigNumber(nftColDataBefore.availableBorrowsInETH.toString())
+        .div(usdcPrice.toString())
+        .multipliedBy(0.95)
+        .toFixed(0)
+    );
+
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).borrow(usdc.address, amountBorrow, landId, borrower.address, "0")
+    );
+
+    await waitForTx(await wrappedKoda.connect(liquidator.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    const nftDebtDataAfterBorrow = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterBorrow.healthFactor.toString()).to.be.bignumber.gt(oneEther.toFixed(0));
+
+    // Drop the health factor below 1
+    const debAmountUnits = await convertToCurrencyUnits(usdc.address, nftDebtDataAfterBorrow.totalDebt.toString());
+    await setNftAssetPriceForDebt(testEnv, "WKODA", "USDC", debAmountUnits, "80");
+    const nftDebtDataAfterOracle = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterOracle.healthFactor.toString()).to.be.bignumber.lt(oneEther.toFixed(0));
+
+    await advanceTimeAndBlock(100);
+
+    // Liquidate USDC loan
+    await mintERC20(testEnv, liquidator, "USDC", depositUnit.toString());
+    await approveERC20WrapperGateway(testEnv, liquidator, "USDC");
+
+    const { liquidatePrice } = await pool.getNftLiquidatePrice(wrappedKoda.address, landId);
+    const liquidateAmount = liquidatePrice.add(liquidatePrice.mul(5).div(100));
+    await waitForTx(
+      await wrapperGateway.connect(liquidator.signer).auction(landId, liquidateAmount, liquidator.address)
+    );
+
+    await increaseTime(nftCfgData.auctionDuration.mul(ONE_HOUR).add(100).toNumber());
+
+    const extraAmount = await convertToCurrencyDecimals(usdc.address, "100");
+    await waitForTx(await wrapperGateway.connect(liquidator.signer).liquidate(landId, extraAmount));
+
+    const loanDataAfter = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfter.state).to.be.equal(ProtocolLoanState.Defaulted, "Invalid loan state after liquidation");
+
+    const kodaOwner = await getKodaOwner();
+    expect(kodaOwner).to.be.equal(liquidator.address, "Invalid koda owner after liquidation");
+
+    await advanceTimeAndBlock(100);
+  });
+
+  it("Borrow USDC and redeem it", async () => {
+    const {
+      users,
+      mockOtherdeed,
+      wrappedKoda,
+      bWKoda,
+      wrapperGateway,
+      wethGateway,
+      usdc,
+      pool,
+      dataProvider,
+      reserveOracle,
+      nftOracle,
+    } = testEnv;
+
+    const [depositor, borrower] = users;
+    const liquidator = users[4];
+    const depositUnit = "200000";
+    const depositSize = await convertToCurrencyDecimals(usdc.address, "200000");
+
+    await sleep(1000 * 1);
+    await setNftAssetPrice(testEnv, "WKODA", kodaInitPrice.toString());
+
+    const landId = testEnv.landIdTracker++;
+
+    const getKodaOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+
+    // mint native nft
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId));
+
+    await advanceTimeAndBlock(100);
+
+    const nftCfgData = await dataProvider.getNftConfigurationData(wrappedKoda.address);
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(usdc.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(
+      await debtToken.connect(borrower.signer).approveDelegation(wrapperGateway.address, MAX_UINT_AMOUNT)
+    );
+
+    // borrow usdc, health factor above 1
+    const nftColDataBefore = await pool.getNftCollateralData(wrappedKoda.address, usdc.address);
+
+    const usdcPrice = await reserveOracle.getAssetPrice(usdc.address);
+    const amountBorrow = await convertToCurrencyDecimals(
+      usdc.address,
+      new BigNumber(nftColDataBefore.availableBorrowsInETH.toString())
+        .div(usdcPrice.toString())
+        .multipliedBy(0.95)
+        .toFixed(0)
+    );
+
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).borrow(usdc.address, amountBorrow, landId, borrower.address, "0")
+    );
+
+    await waitForTx(await wrappedKoda.connect(borrower.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    const nftDebtDataAfterBorrow = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterBorrow.healthFactor.toString()).to.be.bignumber.gt(oneEther.toFixed(0));
+
+    // Drop the health factor below 1
+    const debAmountUnits = await convertToCurrencyUnits(usdc.address, nftDebtDataAfterBorrow.totalDebt.toString());
+    await setNftAssetPriceForDebt(testEnv, "WKODA", "USDC", debAmountUnits, "80");
+    const nftDebtDataAfterOracle = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterOracle.healthFactor.toString()).to.be.bignumber.lt(oneEther.toFixed(0));
+
+    await advanceTimeAndBlock(100);
+
+    // Auction loan
+    await advanceTimeAndBlock(100);
+    await mintERC20(testEnv, liquidator, "USDC", depositUnit.toString());
+    await approveERC20WrapperGateway(testEnv, liquidator, "USDC");
+
+    const { liquidatePrice } = await pool.getNftLiquidatePrice(wrappedKoda.address, landId);
+    const liquidateAmount = liquidatePrice.add(liquidatePrice.mul(5).div(100));
+    await waitForTx(
+      await wrapperGateway.connect(liquidator.signer).auction(landId, liquidateAmount, liquidator.address)
+    );
+
+    await advanceTimeAndBlock(100);
+
+    // Redeem loan
+    await advanceTimeAndBlock(100);
+    await mintERC20(testEnv, borrower, "USDC", depositUnit.toString());
+    await approveERC20WrapperGateway(testEnv, borrower, "USDC");
+
+    await increaseTime(nftCfgData.redeemDuration.mul(ONE_HOUR).sub(3600).toNumber());
+
+    const nftDebtDataBeforeRedeem = await pool.getNftDebtData(wrappedKoda.address, landId);
+    const nftAuctionDataBeforeRedeem = await pool.getNftAuctionData(wrappedKoda.address, landId);
+    const repayAmount = new BigNumber(nftDebtDataBeforeRedeem.totalDebt.toString()).multipliedBy(0.51).toFixed(0);
+    const bidFineAmount = new BigNumber(nftAuctionDataBeforeRedeem.bidFine.toString()).multipliedBy(1.1).toFixed(0);
+
+    await waitForTx(await wrapperGateway.connect(borrower.signer).redeem(landId, repayAmount, bidFineAmount));
+
+    const loanDataAfterRedeem = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfterRedeem.state).to.be.equal(ProtocolLoanState.Active, "Invalid loan state after redeem");
+
+    const kodaOwner = await getKodaOwner();
+    expect(kodaOwner).to.be.equal(wrappedKoda.address, "Invalid koda owner after redeem");
+
+    const wkodaOwner = await wrappedKoda.ownerOf(landId);
+    expect(wkodaOwner).to.be.equal(bWKoda.address, "Invalid wkoda owner after redeem");
+
+    // Repay loan
+    await advanceTimeAndBlock(100);
+    await waitForTx(await wrapperGateway.connect(borrower.signer).repay(landId, MAX_UINT_AMOUNT));
+
+    const loanDataAfterRepay = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfterRepay.state).to.be.equal(ProtocolLoanState.Repaid, "Invalid loan state after redeem");
+
+    await advanceTimeAndBlock(100);
+  });
+
+  it("Borrow ETH and liquidate it", async () => {
+    const {
+      users,
+      mockOtherdeed,
+      wrappedKoda,
+      wrapperGateway,
+      weth,
+      wethGateway,
+      pool,
+      dataProvider,
+      loan,
+      reserveOracle,
+      nftOracle,
+    } = testEnv;
+
+    const [depositor, user] = users;
+    const liquidator = users[4];
+    const depositSize = parseEther("50");
+
+    await sleep(1000 * 1);
+    await setNftAssetPrice(testEnv, "WKODA", kodaInitPrice.toString());
+
+    await advanceTimeAndBlock(100);
+
+    // Deposit with native ETH
+    await waitForTx(
+      await wethGateway.connect(depositor.signer).depositETH(depositor.address, "0", { value: depositSize })
+    );
+
+    await advanceTimeAndBlock(100);
+
+    const landId = testEnv.landIdTracker++;
+
+    const getKodaOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+
+    // mint native nft
+    await waitForTx(await mockOtherdeed.connect(user.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(user.signer).approve(wrapperGateway.address, landId));
+
+    await advanceTimeAndBlock(100);
+
+    const nftCfgData = await dataProvider.getNftConfigurationData(wrappedKoda.address);
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(weth.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(user.signer).approveDelegation(wethGateway.address, MAX_UINT_AMOUNT));
+
+    // borrow eth, health factor above 1
+    const nftColDataBefore = await pool.getNftCollateralData(wrappedKoda.address, weth.address);
+
+    const wethPrice = await reserveOracle.getAssetPrice(weth.address);
+    const amountBorrow = await convertToCurrencyDecimals(
+      weth.address,
+      new BigNumber(nftColDataBefore.availableBorrowsInETH.toString())
+        .div(wethPrice.toString())
+        .multipliedBy(0.95)
+        .toFixed(0)
+    );
+
+    await waitForTx(await wrapperGateway.connect(user.signer).borrowETH(amountBorrow, landId, user.address, "0"));
+
+    await advanceTimeAndBlock(100);
+
+    await waitForTx(await wrappedKoda.connect(liquidator.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    const nftDebtDataAfterBorrow = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterBorrow.healthFactor.toString()).to.be.bignumber.gt(oneEther.toFixed(0));
+
+    // Drop the health factor below 1
+    const debAmountUnits = await convertToCurrencyUnits(weth.address, nftDebtDataAfterBorrow.totalDebt.toString());
+    await setNftAssetPriceForDebt(testEnv, "WKODA", "WETH", debAmountUnits, "80");
+    const nftDebtDataAfterOracle = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterOracle.healthFactor.toString()).to.be.bignumber.lt(oneEther.toFixed(0));
+
+    // Liquidate ETH loan with native ETH
+    const { liquidatePrice } = await pool.getNftLiquidatePrice(wrappedKoda.address, landId);
+    const liquidateAmountSend = liquidatePrice.add(liquidatePrice.mul(5).div(100));
+    await waitForTx(
+      await wrapperGateway
+        .connect(liquidator.signer)
+        .auctionETH(landId, liquidator.address, { value: liquidateAmountSend })
+    );
+
+    await increaseTime(nftCfgData.auctionDuration.mul(ONE_HOUR).add(100).toNumber());
+
+    const extraAmount = await convertToCurrencyDecimals(weth.address, "1");
+    await waitForTx(await wrapperGateway.connect(liquidator.signer).liquidateETH(landId, { value: extraAmount }));
+
+    const loanDataAfter = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfter.state).to.be.equal(ProtocolLoanState.Defaulted, "Invalid loan state after liquidation");
+
+    const kodaOwner = await getKodaOwner();
+    expect(kodaOwner).to.be.equal(liquidator.address, "Invalid koda owner after liquidation");
+
+    await advanceTimeAndBlock(100);
+  });
+
+  it("Borrow ETH and redeem it", async () => {
+    const {
+      users,
+      mockOtherdeed,
+      wrappedKoda,
+      bWKoda,
+      wrapperGateway,
+      weth,
+      wethGateway,
+      pool,
+      dataProvider,
+      loan,
+      reserveOracle,
+      nftOracle,
+    } = testEnv;
+
+    const [depositor, borrower] = users;
+    const liquidator = users[4];
+    const depositSize = parseEther("50");
+
+    await sleep(1000 * 1);
+    await setNftAssetPrice(testEnv, "WKODA", kodaInitPrice.toString());
+
+    // Deposit with native ETH
+    await waitForTx(
+      await wethGateway.connect(depositor.signer).depositETH(depositor.address, "0", { value: depositSize })
+    );
+
+    await advanceTimeAndBlock(100);
+
+    const landId = testEnv.landIdTracker++;
+
+    const getKodaOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+
+    // mint native nft
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId));
+
+    await advanceTimeAndBlock(100);
+
+    const nftCfgData = await dataProvider.getNftConfigurationData(wrappedKoda.address);
+
+    // borrow eth, health factor above 1
+    const nftColDataBefore = await pool.getNftCollateralData(wrappedKoda.address, weth.address);
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(weth.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(borrower.signer).approveDelegation(wethGateway.address, MAX_UINT_AMOUNT));
+
+    const wethPrice = await reserveOracle.getAssetPrice(weth.address);
+    const amountBorrow = await convertToCurrencyDecimals(
+      weth.address,
+      new BigNumber(nftColDataBefore.availableBorrowsInETH.toString())
+        .div(wethPrice.toString())
+        .multipliedBy(0.95)
+        .toFixed(0)
+    );
+
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).borrowETH(amountBorrow, landId, borrower.address, "0")
+    );
+
+    await advanceTimeAndBlock(100);
+
+    await waitForTx(await wrappedKoda.connect(borrower.signer).setApprovalForAll(wrapperGateway.address, true));
+
+    const nftDebtDataAfterBorrow = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterBorrow.healthFactor.toString()).to.be.bignumber.gt(oneEther.toFixed(0));
+
+    // Drop the health factor below 1
+    const debAmountUnits = await convertToCurrencyUnits(weth.address, nftDebtDataAfterBorrow.totalDebt.toString());
+    await setNftAssetPriceForDebt(testEnv, "WKODA", "WETH", debAmountUnits, "80");
+    const nftDebtDataAfterOracle = await pool.getNftDebtData(wrappedKoda.address, landId);
+    expect(nftDebtDataAfterOracle.healthFactor.toString()).to.be.bignumber.lt(oneEther.toFixed(0));
+
+    // Auction ETH loan with native ETH
+    const { liquidatePrice } = await pool.getNftLiquidatePrice(wrappedKoda.address, landId);
+    const liquidateAmountSend = liquidatePrice.add(liquidatePrice.mul(5).div(100));
+    await waitForTx(
+      await wrapperGateway
+        .connect(liquidator.signer)
+        .auctionETH(landId, liquidator.address, { value: liquidateAmountSend })
+    );
+
+    await advanceTimeAndBlock(100);
+
+    // Redeem ETH loan with native ETH
+    await increaseTime(nftCfgData.redeemDuration.mul(ONE_HOUR).sub(3600).toNumber());
+
+    const auctionDataBeforeRedeem = await pool.getNftAuctionData(wrappedKoda.address, landId);
+    const debtDataBeforeRedeem = await pool.getNftDebtData(wrappedKoda.address, landId);
+    const redeemAmount = new BigNumber(debtDataBeforeRedeem.totalDebt.toString()).multipliedBy(0.51).toFixed(0);
+    const bidFineAmount = new BigNumber(auctionDataBeforeRedeem.bidFine.toString()).multipliedBy(1.1).toFixed(0);
+    const redeemAmountSend = new BigNumber(redeemAmount).plus(bidFineAmount).toFixed(0);
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).redeemETH(landId, redeemAmount, bidFineAmount, {
+        value: redeemAmountSend,
+      })
+    );
+
+    const loanDataAfter = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfter.state).to.be.equal(ProtocolLoanState.Active, "Invalid loan state after redeem");
+
+    const kodaOwner = await getKodaOwner();
+    expect(kodaOwner).to.be.equal(wrappedKoda.address, "Invalid koda owner after redeem");
+
+    const wkodaOwner = await wrappedKoda.ownerOf(landId);
+    expect(wkodaOwner).to.be.equal(bWKoda.address, "Invalid wkoda owner after redeem");
+
+    await advanceTimeAndBlock(100);
+
+    // Repay loan
+    const debtDataBeforeRepay = await pool.getNftDebtData(wrappedKoda.address, landId);
+    const repayAmount = new BigNumber(debtDataBeforeRepay.totalDebt.toString()).multipliedBy(1.1).toFixed(0);
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).repayETH(landId, MAX_UINT_AMOUNT, { value: repayAmount })
+    );
+
+    const loanDataAfterRepay = await dataProvider.getLoanDataByLoanId(nftDebtDataAfterBorrow.loanId);
+    expect(loanDataAfterRepay.state).to.be.equal(ProtocolLoanState.Repaid, "Invalid loan state after repay");
+
+    await advanceTimeAndBlock(100);
+  });
+});

--- a/test/wrappergateway.spec.ts
+++ b/test/wrappergateway.spec.ts
@@ -1,0 +1,327 @@
+import BigNumber from "bignumber.js";
+import { BigNumber as BN } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+
+import { getReservesConfigByPool } from "../helpers/configuration";
+import { MAX_UINT_AMOUNT, oneEther, ONE_YEAR } from "../helpers/constants";
+import { getDebtToken } from "../helpers/contracts-getters";
+import { convertToCurrencyDecimals, convertToCurrencyUnits } from "../helpers/contracts-helpers";
+import { advanceBlock, advanceTimeAndBlock, sleep, waitForTx } from "../helpers/misc-utils";
+import { BendPools, iBendPoolAssets, IReserveParams, ProtocolLoanState } from "../helpers/types";
+import { ERC721Factory } from "../types";
+import {
+  approveERC20,
+  approveERC20WrapperGateway,
+  configuration as actionsConfiguration,
+  deposit,
+  mintERC20,
+  setNftAssetPrice,
+} from "./helpers/actions";
+import { makeSuite, TestEnv } from "./helpers/make-suite";
+import { configuration as calculationsConfiguration } from "./helpers/utils/calculations";
+import {
+  getERC20TokenBalance,
+  getLoanData,
+  getReserveAddressFromSymbol,
+  getReserveData,
+} from "./helpers/utils/helpers";
+
+const chai = require("chai");
+const { expect } = chai;
+
+makeSuite("WrapperGateway", (testEnv: TestEnv) => {
+  const zero = BN.from(0);
+
+  before("Initializing configuration", async () => {
+    // Sets BigNumber for this suite, instead of globally
+    BigNumber.config({
+      DECIMAL_PLACES: 0,
+      ROUNDING_MODE: BigNumber.ROUND_DOWN,
+    });
+
+    actionsConfiguration.skipIntegrityCheck = false; //set this to true to execute solidity-coverage
+
+    calculationsConfiguration.reservesParams = <iBendPoolAssets<IReserveParams>>(
+      getReservesConfigByPool(BendPools.proto)
+    );
+  });
+  after("Reset", () => {
+    // Reset BigNumber
+    BigNumber.config({
+      DECIMAL_PLACES: 20,
+      ROUNDING_MODE: BigNumber.ROUND_HALF_UP,
+    });
+  });
+
+  it("Borrow some USDC and repay it", async () => {
+    const { users, mockOtherdeed, wrappedKoda, wrapperGateway, pool, dataProvider, usdc } = testEnv;
+
+    const [depositor, borrower] = users;
+    const depositUnit = "10000";
+    const depositSize = await convertToCurrencyDecimals(usdc.address, depositUnit);
+
+    // Deposit USDC
+    await mintERC20(testEnv, depositor, "USDC", depositUnit.toString());
+    await approveERC20(testEnv, depositor, "USDC");
+    await deposit(testEnv, depositor, "", "USDC", depositUnit.toString(), depositor.address, "success", "");
+
+    const borrowSize1 = await convertToCurrencyDecimals(usdc.address, "1000");
+    const borrowSize2 = await convertToCurrencyDecimals(usdc.address, "2000");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+    const repaySize = borrowSizeAll.add(borrowSizeAll.mul(5).div(100));
+    const landId = testEnv.landIdTracker++;
+
+    // Mint for interest
+    await waitForTx(await usdc.connect(borrower.signer).mint(repaySize.sub(borrowSizeAll).toString()));
+    await approveERC20WrapperGateway(testEnv, borrower, "USDC");
+
+    const getDebtBalance = async () => {
+      const loan = await getLoanData(pool, dataProvider, wrappedKoda.address, `${landId}`, "0");
+
+      return BN.from(loan.currentAmount.toFixed(0));
+    };
+    const getOtherdeedOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+    const getWrappedKodaOwner = async () => {
+      return await wrappedKoda.ownerOf(landId);
+    };
+
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(borrower.signer).approve(wrapperGateway.address, landId));
+
+    const usdcBalanceBefore = await getERC20TokenBalance(usdc.address, borrower.address);
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(usdc.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(
+      await debtToken.connect(borrower.signer).approveDelegation(wrapperGateway.address, MAX_UINT_AMOUNT)
+    );
+
+    // borrow first usdc
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).borrow(usdc.address, borrowSize1, landId, borrower.address, "0")
+    );
+
+    await advanceTimeAndBlock(100);
+
+    // borrow more usdc
+    await waitForTx(
+      await wrapperGateway.connect(borrower.signer).borrow(usdc.address, borrowSize2, landId, borrower.address, "0")
+    );
+
+    const usdcBalanceAfterBorrow = await getERC20TokenBalance(usdc.address, borrower.address);
+    const debtAfterBorrow = await getDebtBalance();
+    const wrapperKodaOwner = await getWrappedKodaOwner();
+
+    expect(usdcBalanceAfterBorrow).to.be.gte(usdcBalanceBefore.add(borrowSizeAll));
+    expect(debtAfterBorrow).to.be.gte(borrowSizeAll);
+
+    await advanceTimeAndBlock(100);
+
+    // Repay partial
+    await waitForTx(await wrapperGateway.connect(borrower.signer).repay(landId, repaySize.div(2)));
+    const usdcBalanceAfterPartialRepay = await getERC20TokenBalance(usdc.address, borrower.address);
+    const debtAfterPartialRepay = await getDebtBalance();
+
+    expect(usdcBalanceAfterPartialRepay).to.be.lt(usdcBalanceAfterBorrow);
+    expect(debtAfterPartialRepay).to.be.lt(debtAfterBorrow);
+    expect(await getOtherdeedOwner()).to.be.eq(wrappedKoda.address);
+    expect(await getWrappedKodaOwner(), "WrappedKoda should owned by loan after partial borrow").to.be.eq(
+      wrapperKodaOwner
+    );
+
+    await advanceTimeAndBlock(100);
+
+    // Repay full
+    await waitForTx(await wrappedKoda.connect(borrower.signer).setApprovalForAll(wrapperGateway.address, true));
+    await waitForTx(await wrapperGateway.connect(borrower.signer).repay(landId, repaySize));
+    const usdcBalanceAfterFullRepay = await getERC20TokenBalance(usdc.address, borrower.address);
+    const debtAfterFullRepay = await getDebtBalance();
+
+    expect(usdcBalanceAfterFullRepay).to.be.lt(usdcBalanceAfterPartialRepay);
+    expect(debtAfterFullRepay).to.be.eq(zero);
+    expect(await getOtherdeedOwner()).to.be.eq(borrower.address);
+  });
+
+  it("Borrow all USDC and repay it", async () => {
+    const { users, mockOtherdeed, wrappedKoda, wrapperGateway, usdc, pool, dataProvider } = testEnv;
+
+    const [depositor, user] = users;
+
+    // advance block to make some interests
+    const secondsToTravel = new BigNumber(365).multipliedBy(ONE_YEAR).div(365).toNumber();
+    await advanceTimeAndBlock(secondsToTravel);
+
+    const usdcReserveData = await getReserveData(dataProvider, usdc.address);
+    const borrowSize = new BigNumber(usdcReserveData.availableLiquidity);
+    const repaySize = borrowSize.plus(borrowSize.multipliedBy(5).dividedBy(100));
+    const landId = testEnv.landIdTracker++;
+
+    await waitForTx(await mockOtherdeed.connect(user.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(user.signer).approve(wrapperGateway.address, landId));
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(usdc.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(user.signer).approveDelegation(wrapperGateway.address, MAX_UINT_AMOUNT));
+
+    // borrow all usdc
+    await waitForTx(
+      await wrapperGateway.connect(user.signer).borrow(usdc.address, borrowSize.toFixed(0), landId, user.address, "0")
+    );
+
+    // Check results
+    const loanDataAfterBorrow = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId);
+    expect(loanDataAfterBorrow.state).to.be.eq(ProtocolLoanState.Active);
+
+    // Repay all usdc
+    await waitForTx(await wrappedKoda.connect(user.signer).setApprovalForAll(wrapperGateway.address, true));
+    await waitForTx(await wrapperGateway.connect(user.signer).repay(landId, MAX_UINT_AMOUNT));
+
+    // Check results
+    const loanDataAfterRepayFull = await dataProvider.getLoanDataByLoanId(loanDataAfterBorrow.loanId);
+    expect(loanDataAfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+  });
+
+  it("Borrow some ETH and repay it", async () => {
+    const { users, mockOtherdeed, wrappedKoda, wrapperGateway, wethGateway, weth, pool, dataProvider, loan } = testEnv;
+
+    const [depositor, user, anotherUser] = users;
+    const depositSize = parseEther("5");
+
+    // Deposit with native ETH
+    await waitForTx(
+      await wethGateway.connect(depositor.signer).depositETH(depositor.address, "0", { value: depositSize })
+    );
+
+    const borrowSize1 = parseEther("1");
+    const borrowSize2 = parseEther("2");
+    const borrowSizeAll = borrowSize1.add(borrowSize2);
+    const repaySize = borrowSizeAll.add(borrowSizeAll.mul(5).div(100));
+    const landId = testEnv.landIdTracker++;
+
+    const getDebtBalance = async () => {
+      const loan = await getLoanData(pool, dataProvider, wrappedKoda.address, `${landId}`, "0");
+      return BN.from(loan.currentAmount.toFixed(0));
+    };
+    const getOtherdeedOwner = async () => {
+      return await mockOtherdeed.ownerOf(landId);
+    };
+    const getWrappedKodaOwner = async () => {
+      return await wrappedKoda.ownerOf(landId);
+    };
+
+    await advanceTimeAndBlock(100);
+
+    await waitForTx(await mockOtherdeed.connect(user.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(user.signer).approve(wrapperGateway.address, landId));
+
+    await advanceTimeAndBlock(100);
+
+    const ethBalanceBefore = await user.signer.getBalance();
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(weth.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(user.signer).approveDelegation(wethGateway.address, MAX_UINT_AMOUNT));
+
+    // borrow first eth
+    await waitForTx(await wrapperGateway.connect(user.signer).borrowETH(borrowSize1, landId, user.address, "0"));
+
+    await advanceTimeAndBlock(100);
+
+    // borrow more eth
+    await waitForTx(await wrapperGateway.connect(user.signer).borrowETH(borrowSize2, landId, user.address, "0"));
+
+    // Check debt
+    const loanDataAfterBorrow = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId);
+    expect(loanDataAfterBorrow.state).to.be.eq(ProtocolLoanState.Active);
+
+    const wrapperKodaOwner = await getWrappedKodaOwner();
+    const debtAfterBorrow = await getDebtBalance();
+
+    expect(await user.signer.getBalance(), "current eth balance shoud increase").to.be.gt(ethBalanceBefore);
+    expect(debtAfterBorrow, "debt should gte borrowSize").to.be.gte(borrowSizeAll);
+
+    await advanceTimeAndBlock(100);
+
+    // Repay partial
+    await waitForTx(
+      await wrapperGateway.connect(user.signer).repayETH(landId, repaySize.div(2), {
+        value: repaySize.div(2),
+      })
+    );
+    const loanDataAfterRepayPart = await dataProvider.getLoanDataByLoanId(loanDataAfterBorrow.loanId);
+    const debtAfterPartialRepay = await getDebtBalance();
+
+    expect(debtAfterPartialRepay).to.be.lt(debtAfterBorrow);
+    expect(await getOtherdeedOwner()).to.be.eq(wrappedKoda.address);
+    expect(await getWrappedKodaOwner(), "WrappedPunk should owned by loan after partial borrow").to.be.eq(
+      wrapperKodaOwner
+    );
+    expect(loanDataAfterRepayPart.state).to.be.eq(ProtocolLoanState.Active);
+
+    await advanceTimeAndBlock(100);
+
+    // Repay full
+    await waitForTx(await wrappedKoda.connect(user.signer).setApprovalForAll(wrapperGateway.address, true));
+    await waitForTx(
+      await wrapperGateway.connect(user.signer).repayETH(landId, MAX_UINT_AMOUNT, {
+        value: repaySize,
+      })
+    );
+    const debtAfterFullRepay = await getDebtBalance();
+    const loanDataAfterRepayFull = await dataProvider.getLoanDataByLoanId(loanDataAfterBorrow.loanId);
+
+    expect(debtAfterFullRepay).to.be.eq(zero);
+    expect(await getOtherdeedOwner()).to.be.eq(user.address);
+    expect(loanDataAfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+  });
+
+  it("Borrow all ETH and repay it", async () => {
+    const { users, pool, mockOtherdeed, wrappedKoda, wrapperGateway, weth, bWETH, wethGateway, dataProvider } = testEnv;
+
+    const [depositor, user] = users;
+    const depositSize = parseEther("5");
+
+    // advance block to make some interests
+    const secondsToTravel = new BigNumber(365).multipliedBy(ONE_YEAR).div(365).toNumber();
+    await advanceTimeAndBlock(secondsToTravel);
+
+    const wethReserveData = await getReserveData(dataProvider, weth.address);
+    const borrowSize = new BigNumber(wethReserveData.availableLiquidity);
+    const repaySize = borrowSize.plus(borrowSize.multipliedBy(5).dividedBy(100));
+    const landId = testEnv.landIdTracker++;
+
+    await waitForTx(await mockOtherdeed.connect(user.signer).mint(landId));
+    await waitForTx(await mockOtherdeed.connect(user.signer).approve(wrapperGateway.address, landId));
+
+    // Delegates borrowing power of WETH to WETHGateway
+    const reserveData = await pool.getReserveData(weth.address);
+    const debtToken = await getDebtToken(reserveData.debtTokenAddress);
+    await waitForTx(await debtToken.connect(user.signer).approveDelegation(wethGateway.address, MAX_UINT_AMOUNT));
+
+    // borrow all eth
+    await waitForTx(
+      await wrapperGateway.connect(user.signer).borrowETH(borrowSize.toFixed(0), landId, user.address, "0")
+    );
+
+    // Check results
+    const loanDataAfterBorrow = await dataProvider.getLoanDataByCollateral(wrappedKoda.address, landId);
+    expect(loanDataAfterBorrow.state).to.be.eq(ProtocolLoanState.Active);
+
+    // Repay all eth
+    await waitForTx(await wrappedKoda.connect(user.signer).setApprovalForAll(wrapperGateway.address, true));
+    await waitForTx(
+      await wrapperGateway.connect(user.signer).repayETH(landId, MAX_UINT_AMOUNT, {
+        value: repaySize.toFixed(0),
+      })
+    );
+
+    // Check results
+    const loanDataAfterRepayFull = await dataProvider.getLoanDataByLoanId(loanDataAfterBorrow.loanId);
+    expect(loanDataAfterRepayFull.state).to.be.eq(ProtocolLoanState.Repaid);
+  });
+});


### PR DESCRIPTION
Users can directly use the original Koda to borrow, no need to care about the wrapper underhood.