### PR TITLE
feat: add chainlink aggregator helper contract for subgraph service

### DIFF
--- a/abis/ChainlinkAggregatorHelper.json
+++ b/abis/ChainlinkAggregatorHelper.json
@@ -1,0 +1,168 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reserve",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "ReserveAggregatorRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "reserve",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "ReserveAggregatorUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "addressProvider",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addressProvider_",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reserve",
+        "type": "address"
+      }
+    ],
+    "name": "removeReserveAggregator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "reserveAggregators",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reserve",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "updateReserveAggregator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/IIncentivesController.json
+++ b/abis/IIncentivesController.json
@@ -2,6 +2,24 @@
   {
     "inputs": [
       {
+        "internalType": "contract IScaledBalanceToken[]",
+        "name": "_assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_emissionsPerSecond",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "configureAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "asset",
         "type": "address"

--- a/abis/NFTOracle.json
+++ b/abis/NFTOracle.json
@@ -18,6 +18,44 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "mappedAsset",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "originAsset",
+        "type": "address"
+      }
+    ],
+    "name": "AssetMappingAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mappedAsset",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "originAsset",
+        "type": "address"
+      }
+    ],
+    "name": "AssetMappingRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "asset",
         "type": "address"
       }
@@ -140,6 +178,25 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "originAsset",
+        "type": "address"
+      }
+    ],
+    "name": "getAssetMapping",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
       }
     ],
     "stateMutability": "view",
@@ -308,6 +365,30 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "originAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "mappedAsset",
+        "type": "address"
+      }
+    ],
+    "name": "isAssetMapped",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "maxPriceDeviation",
     "outputs": [
@@ -463,6 +544,29 @@
       }
     ],
     "name": "setAssetData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "originAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "mappedAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "added",
+        "type": "bool"
+      }
+    ],
+    "name": "setAssetMapping",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/interfaces/IReserveOracle.sol
+++ b/contracts/interfaces/IReserveOracle.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+/************
+@title IReserveOracle interface
+@notice Interface for getting Reserve price oracle.*/
+interface IReserveOracle {
+  /* CAUTION: Price uint is ETH based (WEI, 18 decimals) */
+  /***********
+    @dev returns the asset price in ETH
+     */
+  function getAssetPrice(address asset) external view returns (uint256);
+
+  // get twap price depending on _period
+  function getTwapPrice(address _priceFeedKey, uint256 _interval) external view returns (uint256);
+
+  function priceFeedMap(address _priceFeedKey) external view returns (AggregatorV3Interface);
+}

--- a/contracts/misc/ChainlinkAggregatorHelper.sol
+++ b/contracts/misc/ChainlinkAggregatorHelper.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.4;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+import {ILendPoolAddressesProvider} from "../interfaces/ILendPoolAddressesProvider.sol";
+import {IReserveOracle} from "../interfaces/IReserveOracle.sol";
+
+/*
+  @dev Helper contract for reserve oracle subgraph services
+ */
+contract ChainlinkAggregatorHelper is Initializable, OwnableUpgradeable {
+  event ReserveAggregatorUpdated(address indexed reserve, address indexed aggregator);
+  event ReserveAggregatorRemoved(address indexed reserve, address indexed aggregator);
+
+  address public addressProvider;
+  mapping(address => address) public reserveAggregators;
+
+  function initialize(address addressProvider_) external initializer {
+    __Ownable_init();
+
+    addressProvider = addressProvider_;
+  }
+
+  /*
+    @dev update reserve (internal) aggregator for subgraph services
+    * @param reserve The address of the reserve
+    * @param aggregator The address of the internal aggregator
+   */
+  function updateReserveAggregator(address reserve, address aggregator) external onlyOwner {
+    ILendPoolAddressesProvider provider = ILendPoolAddressesProvider(addressProvider);
+    IReserveOracle oracle = IReserveOracle(provider.getReserveOracle());
+
+    AggregatorV3Interface curAggProxy = oracle.priceFeedMap(reserve);
+    require(address(curAggProxy) != address(0), "ChainlinkAggregatorHelper: reserve not exist");
+    require(address(curAggProxy) != aggregator, "ChainlinkAggregatorHelper: aggregator is proxy");
+
+    require(reserveAggregators[reserve] != aggregator, "ChainlinkAggregatorHelper: aggregator is same");
+    reserveAggregators[reserve] = aggregator;
+    emit ReserveAggregatorUpdated(reserve, aggregator);
+  }
+
+  /*
+    @dev remove reserve (internal) aggregator for subgraph services
+    * @param reserve The address of the reserve
+    * @param aggregator The address of the internal aggregator
+   */
+  function removeReserveAggregator(address reserve) external onlyOwner {
+    address aggregator = reserveAggregators[reserve];
+    require(aggregator != address(0), "ChainlinkAggregatorHelper: aggregator is zero");
+
+    delete reserveAggregators[reserve];
+    emit ReserveAggregatorRemoved(reserve, aggregator);
+  }
+}

--- a/deployments/deployed-contracts-goerli.json
+++ b/deployments/deployed-contracts-goerli.json
@@ -148,5 +148,11 @@
   "rateStrategyStableThree": {
     "address": "0x124A8d7D5E8C72e0951D1B247bDac02640914b19",
     "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
+  },
+  "ChainlinkAggregatorHelperImpl": {
+    "address": "0xC133Cd86FE48344B7ce86eC4368Cc37C3FEfe012"
+  },
+  "ChainlinkAggregatorHelper": {
+    "address": "0x2302B5faEBE36C033939C9C312390ce5B1589E0d"
   }
 }

--- a/deployments/deployed-contracts-main.json
+++ b/deployments/deployed-contracts-main.json
@@ -137,5 +137,12 @@
   "rateStrategyUSDT230628": {
     "address": "0x8B8BefFDf3aC2C32aF746DaFaE49E085f4D07267",
     "deployer": "0x868964fa49a6fd6e116FE82c8f4165904406f479"
+  },
+  "ChainlinkAggregatorHelperImpl": {
+    "address": "0x4E840EcC421016c132E8515353c5Ee2Fe162D8a8"
+  },
+  "ChainlinkAggregatorHelper": {
+    "address": "0xDcdE2dBd52B493de0b2C6Ff707562eEf7C3C7706",
+    "deployer": "0x868964fa49a6fd6e116FE82c8f4165904406f479"
   }
 }

--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -62,6 +62,7 @@ import {
   MockerERC721WrapperFactory,
   WrapperGatewayFactory,
   MockerERC721Wrapper,
+  ChainlinkAggregatorHelperFactory,
 } from "../types";
 import {
   withSaveAndVerify,
@@ -307,6 +308,12 @@ export const deployMockChainlinkOracle = async (decimals: string, verify?: boole
     [decimals],
     verify
   );
+
+export const deployChainlinkAggregatorHelper = async (args: [], verify?: boolean) => {
+  const aggHelperImpl = await new ChainlinkAggregatorHelperFactory(await getDeploySigner()).deploy();
+  await insertContractAddressInDb(eContractid.ChainlinkAggregatorHelperImpl, aggHelperImpl.address);
+  return withSaveAndVerify(aggHelperImpl, eContractid.ChainlinkAggregatorHelper, [], verify);
+};
 
 export const deployNFTOracle = async (verify?: boolean) => {
   const oracleImpl = await new NFTOracleFactory(await getDeploySigner()).deploy();

--- a/helpers/contracts-getters.ts
+++ b/helpers/contracts-getters.ts
@@ -41,6 +41,7 @@ import {
   MockerERC721WrapperFactory,
   MintableERC721,
   WrapperGatewayFactory,
+  ChainlinkAggregatorHelperFactory,
 } from "../types";
 import { IERC20DetailedFactory } from "../types/IERC20DetailedFactory";
 import { IERC721DetailedFactory } from "../types/IERC721DetailedFactory";
@@ -123,6 +124,18 @@ export const getReserveOracleImpl = async (address?: tEthereumAddress) =>
 export const getMockChainlinkOracle = async (address?: tEthereumAddress) =>
   await MockChainlinkOracleFactory.connect(
     address || (await getDb(DRE.network.name).get(`${eContractid.MockChainlinkOracle}`).value()).address,
+    await getDeploySigner()
+  );
+
+export const getChainlinkAggregatorHelper = async (address?: tEthereumAddress) =>
+  await ChainlinkAggregatorHelperFactory.connect(
+    address || (await getDb(DRE.network.name).get(`${eContractid.ChainlinkAggregatorHelper}`).value()).address,
+    await getDeploySigner()
+  );
+
+export const getChainlinkAggregatorHelperImpl = async (address?: tEthereumAddress) =>
+  await ChainlinkAggregatorHelperFactory.connect(
+    address || (await getDb(DRE.network.name).get(`${eContractid.ChainlinkAggregatorHelperImpl}`).value()).address,
     await getDeploySigner()
   );
 

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -44,6 +44,8 @@ export enum eContractid {
   MockChainlinkOracle = "MockChainlinkOracle",
   MockNFTOracle = "MockNFTOracle",
   MockReserveOracle = "MockReserveOracle",
+  ChainlinkAggregatorHelper = "ChainlinkAggregatorHelper",
+  ChainlinkAggregatorHelperImpl = "ChainlinkAggregatorHelperImpl",
   InterestRate = "InterestRate",
   BendUpgradeableProxy = "BendUpgradeableProxy",
   BendProxyAdminTest = "BendProxyAdminTest",

--- a/scripts/updateAbis.js
+++ b/scripts/updateAbis.js
@@ -17,7 +17,7 @@ const protocolContractList = [
   "WrapperGateway",
 ];
 
-const miscContractList = ["UiPoolDataProvider", "BendProtocolDataProvider", "WalletBalanceProvider"];
+const miscContractList = ["UiPoolDataProvider", "BendProtocolDataProvider", "WalletBalanceProvider", "ChainlinkAggregatorHelper"];
 
 const interfacesContractList = ["IERC20Detailed", "IERC721Detailed", "IIncentivesController"];
 

--- a/tasks/full/oracle-helper.ts
+++ b/tasks/full/oracle-helper.ts
@@ -1,0 +1,73 @@
+import { task } from "hardhat/config";
+import {
+  getContractAddressInDb,
+  insertContractAddressInDb,
+  tryGetContractAddressInDb,
+} from "../../helpers/contracts-helpers";
+import { deployBendUpgradeableProxy, deployChainlinkAggregatorHelper } from "../../helpers/contracts-deployments";
+import { eNetwork, eContractid } from "../../helpers/types";
+import { waitForTx, notFalsyOrZeroAddress } from "../../helpers/misc-utils";
+import { ConfigNames, loadPoolConfig } from "../../helpers/configuration";
+import {
+  getBendProxyAdminById,
+  getBendUpgradeableProxy,
+  getChainlinkAggregatorHelper,
+  getChainlinkAggregatorHelperImpl,
+  getLendPoolAddressesProvider,
+} from "../../helpers/contracts-getters";
+import { BendUpgradeableProxy, ChainlinkAggregatorHelper } from "../../types";
+
+task("dev:deploy-aggregator-helper", "Deploy aggregator helper for dev enviroment")
+  .addFlag("verify", "Verify contracts at Etherscan")
+  .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
+  .setAction(async ({ verify, pool }, DRE) => {
+    try {
+      await DRE.run("set-DRE");
+      await DRE.run("compile");
+
+      const network = <eNetwork>DRE.network.name;
+      const poolConfig = loadPoolConfig(pool);
+
+      const addressProvider = await getLendPoolAddressesProvider();
+      const aggHelperAddress = await tryGetContractAddressInDb(eContractid.ChainlinkAggregatorHelper);
+
+      const proxyAdmin = await getBendProxyAdminById(eContractid.BendProxyAdminPool);
+      const proxyOwnerAddress = await proxyAdmin.owner();
+
+      const aggHelperImpl = await deployChainlinkAggregatorHelper([], verify);
+      //const aggHelperImpl = await getChainlinkAggregatorHelperImpl();
+      const initEncodedData = aggHelperImpl.interface.encodeFunctionData("initialize", [addressProvider.address]);
+
+      let aggHelper: ChainlinkAggregatorHelper;
+      let aggHelperProxy: BendUpgradeableProxy;
+
+      if (aggHelperAddress != undefined && notFalsyOrZeroAddress(aggHelperAddress)) {
+        console.log("Upgrading exist aggregator helper proxy to new implementation...");
+
+        await insertContractAddressInDb(eContractid.ChainlinkAggregatorHelper, aggHelperAddress);
+
+        aggHelperProxy = await getBendUpgradeableProxy(aggHelperAddress);
+        // only proxy admin can do upgrading
+        const ownerSigner = DRE.ethers.provider.getSigner(proxyOwnerAddress);
+        await waitForTx(await proxyAdmin.connect(ownerSigner).upgrade(aggHelperProxy.address, aggHelperImpl.address));
+
+        aggHelper = await getChainlinkAggregatorHelper(aggHelperProxy.address);
+      } else {
+        console.log("Deploying new aggregator helper proxy & implementation...");
+
+        aggHelperProxy = await deployBendUpgradeableProxy(
+          eContractid.ChainlinkAggregatorHelper,
+          proxyAdmin.address,
+          aggHelperImpl.address,
+          initEncodedData,
+          verify
+        );
+
+        aggHelper = await getChainlinkAggregatorHelper(aggHelperProxy.address);
+      }
+
+      console.log("Aggregator Helper: proxy %s, implementation %s", aggHelper.address, aggHelperImpl.address);
+    } catch (error) {
+      throw error;
+    }
+  });


### PR DESCRIPTION
* Chainlink maybe update the reserve internal aggregator but without any event
* Using this helper contract to manually trigger updating internal aggregator in subgraph service;
* Another solution is to track and process the ENS PublicResolver contracts AddrChanged event, Eg. aggregator.eth-usd.data.eth;