### PR TITLE
feat: disable borrow when nft price is stale

### DIFF
--- a/abis/NFTOracle.json
+++ b/abis/NFTOracle.json
@@ -433,6 +433,25 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_nftContract",
+        "type": "address"
+      }
+    ],
+    "name": "isPriceStale",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "maxPriceDeviation",
     "outputs": [
@@ -522,6 +541,25 @@
       {
         "internalType": "bool",
         "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nftPriceStale",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
         "type": "bool"
       }
     ],
@@ -701,6 +739,24 @@
       }
     ],
     "name": "setPriceFeedAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_nftContracts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "val",
+        "type": "bool"
+      }
+    ],
+    "name": "setPriceStale",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/interfaces/INFTOracle.sol
+++ b/contracts/interfaces/INFTOracle.sol
@@ -29,4 +29,8 @@ interface INFTOracle {
   function getAssetMapping(address _nftContract) external view returns (address[] memory);
 
   function isAssetMapped(address originAsset, address mappedAsset) external view returns (bool);
+
+  function setPriceStale(address _nftContract, bool val) external;
+
+  function isPriceStale(address _nftContract) external view returns (bool);
 }

--- a/contracts/interfaces/INFTOracle.sol
+++ b/contracts/interfaces/INFTOracle.sol
@@ -30,7 +30,7 @@ interface INFTOracle {
 
   function isAssetMapped(address originAsset, address mappedAsset) external view returns (bool);
 
-  function setPriceStale(address _nftContract, bool val) external;
+  function setPriceStale(address[] calldata _nftContracts, bool val) external;
 
   function isPriceStale(address _nftContract) external view returns (bool);
 }

--- a/contracts/interfaces/INFTOracleGetter.sol
+++ b/contracts/interfaces/INFTOracleGetter.sol
@@ -10,4 +10,6 @@ interface INFTOracleGetter {
     @dev returns the asset price in ETH
      */
   function getAssetPrice(address asset) external view returns (uint256);
+
+  function isPriceStale(address asset) external view returns (bool);
 }

--- a/contracts/libraries/helpers/Errors.sol
+++ b/contracts/libraries/helpers/Errors.sol
@@ -47,6 +47,7 @@ library Errors {
   string public constant VL_SPECIFIED_LOAN_NOT_BORROWED_BY_USER = "317";
   string public constant VL_SPECIFIED_RESERVE_NOT_BORROWED_BY_USER = "318";
   string public constant VL_HEALTH_FACTOR_HIGHER_THAN_LIQUIDATION_THRESHOLD = "319";
+  string public constant VL_PRICE_STALE = "320";
 
   //lend pool errors
   string public constant LP_CALLER_NOT_LEND_POOL_CONFIGURATOR = "400"; // 'The caller of the function is not the lending pool configurator'

--- a/contracts/libraries/logic/ValidationLogic.sol
+++ b/contracts/libraries/logic/ValidationLogic.sol
@@ -11,6 +11,7 @@ import {Errors} from "../helpers/Errors.sol";
 import {DataTypes} from "../types/DataTypes.sol";
 import {IInterestRate} from "../../interfaces/IInterestRate.sol";
 import {ILendPoolLoan} from "../../interfaces/ILendPoolLoan.sol";
+import {INFTOracleGetter} from "../../interfaces/INFTOracleGetter.sol";
 
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {SafeERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
@@ -73,6 +74,7 @@ library ValidationLogic {
     bool stableRateBorrowingEnabled;
     bool nftIsActive;
     bool nftIsFrozen;
+    bool isPriceStale;
     address loanReserveAsset;
     address loanBorrower;
   }
@@ -120,6 +122,9 @@ library ValidationLogic {
     (vars.nftIsActive, vars.nftIsFrozen) = nftData.configuration.getFlags();
     require(vars.nftIsActive, Errors.VL_NO_ACTIVE_NFT);
     require(!vars.nftIsFrozen, Errors.VL_NFT_FROZEN);
+
+    vars.isPriceStale = INFTOracleGetter(nftOracle).isPriceStale(nftAsset);
+    require(!vars.isPriceStale, Errors.VL_PRICE_STALE);
 
     (vars.currentLtv, vars.currentLiquidationThreshold, ) = nftData.configuration.getCollateralParams();
 

--- a/contracts/protocol/NFTOracle.sol
+++ b/contracts/protocol/NFTOracle.sol
@@ -64,6 +64,7 @@ contract NFTOracle is INFTOracle, Initializable, OwnableUpgradeable, BlockContex
   mapping(address => address) private _mappedAssetToOriginalAsset;
   uint8 public decimals;
   uint256 public decimalPrecision;
+  mapping(address => bool) public nftPriceStale;
 
   // !!! For upgradable, MUST append one new variable above !!!
   //////////////////////////////////////////////////////////////////////////////
@@ -399,5 +400,20 @@ contract NFTOracle is INFTOracle, Initializable, OwnableUpgradeable, BlockContex
 
   function setTwapInterval(uint256 _twapInterval) external override onlyOwner {
     twapInterval = _twapInterval;
+  }
+
+  function setPriceStale(address _nftContract, bool val) public override onlyOwner {
+    address sender = _msgSender();
+    if (val) {
+      require((sender == priceFeedAdmin) || (sender == owner()), "NFTOracle: invalid caller");
+    } else {
+      require(sender == owner(), "NFTOracle: invalid caller");
+    }
+
+    nftPriceStale[_nftContract] = val;
+  }
+
+  function isPriceStale(address _nftContract) public view override returns (bool) {
+    return nftPriceStale[_nftContract];
   }
 }

--- a/contracts/protocol/NFTOracle.sol
+++ b/contracts/protocol/NFTOracle.sol
@@ -417,6 +417,13 @@ contract NFTOracle is INFTOracle, Initializable, OwnableUpgradeable, BlockContex
       requireKeyExisted(_nftContracts[i], true);
       nftPriceStale[_nftContracts[i]] = val;
       emit SetPriceStale(_nftContracts[i], val);
+
+      // Set flag for mapped assets
+      address[] memory mappedAddresses = _originalAssetToMappedAsset[_nftContracts[i]].values();
+      for (uint256 j = 0; j < mappedAddresses.length; j++) {
+        nftPriceStale[mappedAddresses[j]] = val;
+        emit SetPriceStale(mappedAddresses[j], val);
+      }
     }
   }
 

--- a/deployments/deployed-contracts-sepolia.json
+++ b/deployments/deployed-contracts-sepolia.json
@@ -93,11 +93,10 @@
     "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
   },
   "NFTOracleImpl": {
-    "address": "0x958f36955e10FFaa0aC92aA65acB30Ef6268421c"
+    "address": "0xA7bb6431BF998D4e3380ed73DcB226e23E37AA27"
   },
   "NFTOracle": {
-    "address": "0xF143144Fb2703C8aeefD0c4D06d29F5Bb0a9C60A",
-    "deployer": "0xafF5C36642385b6c7Aaf7585eC785aB2316b5db6"
+    "address": "0xF143144Fb2703C8aeefD0c4D06d29F5Bb0a9C60A"
   },
   "InterestRate": {
     "address": "0x3D8F428874a7fBde38a3EFBA48740bA6dD6E767f",

--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -44,7 +44,7 @@ export const NETWORKS_RPC_URL: iParamsPerNetwork<string> = {
 };
 
 export const NETWORKS_DEFAULT_GAS: iParamsPerNetwork<number> = {
-  [eEthereumNetwork.sepolia]: 15 * GWEI,
+  [eEthereumNetwork.sepolia]: 35 * GWEI,
   [eEthereumNetwork.goerli]: 65 * GWEI,
   [eEthereumNetwork.rinkeby]: 65 * GWEI,
   [eEthereumNetwork.main]: 15 * GWEI,

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -143,6 +143,7 @@ export enum ProtocolErrors {
   VL_INVALID_RESERVE_ADDRESS = "316",
   VL_SPECIFIED_LOAN_NOT_BORROWED_BY_USER = "317",
   VL_SPECIFIED_RESERVE_NOT_BORROWED_BY_USER = "318",
+  VL_PRICE_STALE = "320",
 
   //lend pool errors
   LP_CALLER_NOT_LEND_POOL_CONFIGURATOR = "400", // 'The caller of the function is not the lending pool configurator'


### PR DESCRIPTION
* Oracle Keeper set the price stale flag to true when NFT price changing sharply, e.g. up or down exceed 20%;
* Borrowing logic add checks for the NFT price flag is valid or not;