### PR TITLE
feat: max collateral cap

### DIFF
--- a/abis/LendPool.json
+++ b/abis/LendPool.json
@@ -859,6 +859,11 @@
             "internalType": "uint256",
             "name": "maxTokenId",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxCollateralCap",
+            "type": "uint256"
           }
         ],
         "internalType": "struct DataTypes.NftData",
@@ -1072,6 +1077,11 @@
             "internalType": "uint8",
             "name": "id",
             "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxUtilizationRate",
+            "type": "uint256"
           }
         ],
         "internalType": "struct DataTypes.ReserveData",
@@ -1389,6 +1399,24 @@
       },
       {
         "internalType": "uint256",
+        "name": "maxCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNftMaxCollateralCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
         "name": "maxSupply",
         "type": "uint256"
       },
@@ -1466,6 +1494,24 @@
       }
     ],
     "name": "setReserveInterestRateAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxUtilRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "setReserveMaxUtilizationRate",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/abis/LendPoolAddressesProvider.json
+++ b/abis/LendPoolAddressesProvider.json
@@ -267,6 +267,19 @@
     "type": "event"
   },
   {
+    "inputs": [],
+    "name": "RISK_ADMIN",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/abis/LendPoolConfigurator.json
+++ b/abis/LendPoolConfigurator.json
@@ -245,6 +245,25 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "maxCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "NftMaxCollateralCapChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "maxSupply",
         "type": "uint256"
       },
@@ -444,10 +463,42 @@
         "internalType": "address",
         "name": "asset",
         "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxUtilRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReserveMaxUtilizationRateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
       }
     ],
     "name": "ReserveUnfrozen",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "RISK_ADMIN",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [
@@ -543,9 +594,14 @@
             "internalType": "uint256",
             "name": "maxTokenId",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxCollateralCap",
+            "type": "uint256"
           }
         ],
-        "internalType": "struct ILendPoolConfigurator.ConfigNftInput[]",
+        "internalType": "struct ConfigTypes.ConfigNftInput[]",
         "name": "inputs",
         "type": "tuple[]"
       }
@@ -568,9 +624,14 @@
             "internalType": "uint256",
             "name": "reserveFactor",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxUtilizationRate",
+            "type": "uint256"
           }
         ],
-        "internalType": "struct ILendPoolConfigurator.ConfigReserveInput[]",
+        "internalType": "struct ConfigTypes.ConfigReserveInput[]",
         "name": "inputs",
         "type": "tuple[]"
       }
@@ -929,6 +990,24 @@
       },
       {
         "internalType": "uint256",
+        "name": "maxCap",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNftMaxCollateralCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
         "name": "maxSupply",
         "type": "uint256"
       },
@@ -1042,6 +1121,24 @@
       }
     ],
     "name": "setReserveInterestRateAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxUtilRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "setReserveMaxUtilizationRate",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/interfaces/ILendPool.sol
+++ b/contracts/interfaces/ILendPool.sol
@@ -464,6 +464,8 @@ interface ILendPool {
 
   function setReserveConfiguration(address asset, uint256 configuration) external;
 
+  function setReserveMaxUtilizationRate(address asset, uint256 maxUtilRate) external;
+
   function setNftConfiguration(address asset, uint256 configuration) external;
 
   function setNftMaxSupplyAndTokenId(

--- a/contracts/interfaces/ILendPool.sol
+++ b/contracts/interfaces/ILendPool.sol
@@ -472,6 +472,8 @@ interface ILendPool {
     uint256 maxTokenId
   ) external;
 
+  function setNftMaxCollateralCap(address asset, uint256 maxCap) external;
+
   function setMaxNumberOfReserves(uint256 val) external;
 
   function setMaxNumberOfNfts(uint256 val) external;

--- a/contracts/interfaces/ILendPoolConfigurator.sol
+++ b/contracts/interfaces/ILendPoolConfigurator.sol
@@ -2,11 +2,6 @@
 pragma solidity 0.8.4;
 
 interface ILendPoolConfigurator {
-  struct ConfigReserveInput {
-    address asset;
-    uint256 reserveFactor;
-  }
-
   /**
    * @dev Emitted when a reserve is initialized.
    * @param asset The address of the underlying asset of the reserve
@@ -78,6 +73,8 @@ interface ILendPoolConfigurator {
    **/
   event ReserveInterestRateChanged(address indexed asset, address strategy);
 
+  event ReserveMaxUtilizationRateChanged(address indexed asset, uint256 maxUtilRate);
+
   /**
    * @dev Emitted when a nft is initialized.
    * @param asset The address of the underlying asset of the nft
@@ -137,6 +134,8 @@ interface ILendPoolConfigurator {
   event NftMinBidFineChanged(address indexed asset, uint256 minBidFine);
 
   event NftMaxSupplyAndTokenIdChanged(address indexed asset, uint256 maxSupply, uint256 maxTokenId);
+
+  event NftMaxCollateralCapChanged(address indexed asset, uint256 maxCap);
 
   event LoanRepaidInterceptorApproval(address indexed interceptor, bool approved);
 

--- a/contracts/interfaces/ILendPoolConfigurator.sol
+++ b/contracts/interfaces/ILendPoolConfigurator.sol
@@ -7,20 +7,6 @@ interface ILendPoolConfigurator {
     uint256 reserveFactor;
   }
 
-  struct ConfigNftInput {
-    address asset;
-    uint256 baseLTV;
-    uint256 liquidationThreshold;
-    uint256 liquidationBonus;
-    uint256 redeemDuration;
-    uint256 auctionDuration;
-    uint256 redeemFine;
-    uint256 redeemThreshold;
-    uint256 minBidFine;
-    uint256 maxSupply;
-    uint256 maxTokenId;
-  }
-
   /**
    * @dev Emitted when a reserve is initialized.
    * @param asset The address of the underlying asset of the reserve

--- a/contracts/libraries/helpers/Errors.sol
+++ b/contracts/libraries/helpers/Errors.sol
@@ -72,6 +72,7 @@ library Errors {
   string public constant LP_NFT_SUPPLY_NUM_EXCEED_MAX_LIMIT = "418";
   string public constant LP_CALLER_NOT_VALID_INTERCEPTOR = "419";
   string public constant LP_CALLER_NOT_VALID_LOCKER = "420";
+  string public constant LP_NFT_COLLATERAL_NUM_EXCEED_CAP_LIMIT = "421";
 
   //lend pool loan errors
   string public constant LPL_INVALID_LOAN_STATE = "480";

--- a/contracts/libraries/helpers/Errors.sol
+++ b/contracts/libraries/helpers/Errors.sol
@@ -49,6 +49,8 @@ library Errors {
   string public constant VL_SPECIFIED_LOAN_NOT_BORROWED_BY_USER = "317";
   string public constant VL_SPECIFIED_RESERVE_NOT_BORROWED_BY_USER = "318";
   string public constant VL_HEALTH_FACTOR_HIGHER_THAN_LIQUIDATION_THRESHOLD = "319";
+  string public constant VL_PRICE_STALE = "320";
+  string public constant VL_EXCEED_MAX_UTILIZATION_RATE = "321";
 
   //lend pool errors
   string public constant LP_CALLER_NOT_LEND_POOL_CONFIGURATOR = "400"; // 'The caller of the function is not the lending pool configurator'

--- a/contracts/libraries/logic/BorrowLogic.sol
+++ b/contracts/libraries/logic/BorrowLogic.sol
@@ -88,6 +88,7 @@ library BorrowLogic {
     address nftOracle;
     address loanAddress;
     uint256 totalSupply;
+    uint256 bnftTotalSupply;
   }
 
   /**
@@ -183,6 +184,9 @@ library BorrowLogic {
     );
 
     if (vars.loanId == 0) {
+      vars.bnftTotalSupply = IERC721EnumerableUpgradeable(nftData.bNftAddress).totalSupply();
+      require(vars.bnftTotalSupply < nftData.maxCollateralCap, Errors.LP_NFT_COLLATERAL_NUM_EXCEED_CAP_LIMIT);
+
       IERC721Upgradeable(params.nftAsset).safeTransferFrom(vars.initiator, address(this), params.nftTokenId);
 
       vars.loanId = ILendPoolLoan(vars.loanAddress).createLoan(

--- a/contracts/libraries/logic/ConfiguratorLogic.sol
+++ b/contracts/libraries/logic/ConfiguratorLogic.sol
@@ -15,6 +15,7 @@ import {NftConfiguration} from "../../libraries/configuration/NftConfiguration.s
 import {DataTypes} from "../../libraries/types/DataTypes.sol";
 import {ConfigTypes} from "../../libraries/types/ConfigTypes.sol";
 import {Errors} from "../../libraries/helpers/Errors.sol";
+import {PercentageMath} from "../../libraries/math/PercentageMath.sol";
 
 /**
  * @title ConfiguratorLogic library
@@ -22,6 +23,7 @@ import {Errors} from "../../libraries/helpers/Errors.sol";
  * @notice Implements the logic to configuration feature
  */
 library ConfiguratorLogic {
+  using PercentageMath for uint256;
   using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
   using NftConfiguration for DataTypes.NftConfigurationMap;
 
@@ -45,6 +47,23 @@ library ConfiguratorLogic {
    * @param bNft The address of the associated bNFT contract
    **/
   event NftInitialized(address indexed asset, address indexed bNft);
+
+  event NftConfigurationChanged(
+    address indexed asset,
+    uint256 ltv,
+    uint256 liquidationThreshold,
+    uint256 liquidationBonus
+  );
+
+  event NftAuctionChanged(address indexed asset, uint256 redeemDuration, uint256 auctionDuration, uint256 redeemFine);
+
+  event NftRedeemThresholdChanged(address indexed asset, uint256 redeemThreshold);
+
+  event NftMinBidFineChanged(address indexed asset, uint256 minBidFine);
+
+  event NftMaxSupplyAndTokenIdChanged(address indexed asset, uint256 maxSupply, uint256 maxTokenId);
+
+  event NftMaxCollateralCapChanged(address indexed asset, uint256 maxCap);
 
   /**
    * @dev Emitted when an bToken implementation is upgraded
@@ -130,6 +149,72 @@ library ConfiguratorLogic {
     pool_.setNftConfiguration(input.underlyingAsset, currentConfig.data);
 
     emit NftInitialized(input.underlyingAsset, bNftProxy);
+  }
+
+  function executeBatchConfigNft(ILendPool cachedPool, ConfigTypes.ConfigNftInput[] calldata inputs) external {
+    for (uint256 i = 0; i < inputs.length; i++) {
+      DataTypes.NftConfigurationMap memory currentConfig = cachedPool.getNftConfiguration(inputs[i].asset);
+
+      //validation of the parameters: the LTV can
+      //only be lower or equal than the liquidation threshold
+      //(otherwise a loan against the asset would cause instantaneous liquidation)
+      require(inputs[i].baseLTV <= inputs[i].liquidationThreshold, Errors.LPC_INVALID_CONFIGURATION);
+
+      if (inputs[i].liquidationThreshold != 0) {
+        //liquidation bonus must be smaller than or equal 100.00%
+        require(inputs[i].liquidationBonus <= PercentageMath.PERCENTAGE_FACTOR, Errors.LPC_INVALID_CONFIGURATION);
+      } else {
+        require(inputs[i].liquidationBonus == 0, Errors.LPC_INVALID_CONFIGURATION);
+      }
+
+      // collateral parameters
+      currentConfig.setLtv(inputs[i].baseLTV);
+      currentConfig.setLiquidationThreshold(inputs[i].liquidationThreshold);
+      currentConfig.setLiquidationBonus(inputs[i].liquidationBonus);
+
+      // auction parameters
+      currentConfig.setRedeemDuration(inputs[i].redeemDuration);
+      currentConfig.setAuctionDuration(inputs[i].auctionDuration);
+      currentConfig.setRedeemFine(inputs[i].redeemFine);
+      currentConfig.setRedeemThreshold(inputs[i].redeemThreshold);
+      currentConfig.setMinBidFine(inputs[i].minBidFine);
+
+      cachedPool.setNftConfiguration(inputs[i].asset, currentConfig.data);
+
+      emit NftConfigurationChanged(
+        inputs[i].asset,
+        inputs[i].baseLTV,
+        inputs[i].liquidationThreshold,
+        inputs[i].liquidationBonus
+      );
+      emit NftAuctionChanged(
+        inputs[i].asset,
+        inputs[i].redeemDuration,
+        inputs[i].auctionDuration,
+        inputs[i].redeemFine
+      );
+      emit NftRedeemThresholdChanged(inputs[i].asset, inputs[i].redeemThreshold);
+      emit NftMinBidFineChanged(inputs[i].asset, inputs[i].minBidFine);
+
+      // max limit
+      cachedPool.setNftMaxSupplyAndTokenId(inputs[i].asset, inputs[i].maxSupply, inputs[i].maxTokenId);
+      emit NftMaxSupplyAndTokenIdChanged(inputs[i].asset, inputs[i].maxSupply, inputs[i].maxTokenId);
+
+      cachedPool.setNftMaxCollateralCap(inputs[i].asset, inputs[i].maxCollateralCap);
+      emit NftMaxCollateralCapChanged(inputs[i].asset, inputs[i].maxCollateralCap);
+    }
+  }
+
+  function executeSetNftMaxCollateralCap(
+    ILendPool cachedPool,
+    address[] calldata assets,
+    uint256 maxCap
+  ) external {
+    for (uint256 i = 0; i < assets.length; i++) {
+      cachedPool.setNftMaxCollateralCap(assets[i], maxCap);
+
+      emit NftMaxCollateralCapChanged(assets[i], maxCap);
+    }
   }
 
   function executeUpdateBToken(ILendPool cachedPool, ConfigTypes.UpdateBTokenInput calldata input) external {

--- a/contracts/libraries/logic/ValidationLogic.sol
+++ b/contracts/libraries/logic/ValidationLogic.sol
@@ -131,7 +131,7 @@ library ValidationLogic {
     );
     vars.totalDebt += amount;
     vars.utilizationRate = vars.totalDebt.rayDiv(vars.availableLiquidity + (vars.totalDebt));
-    require(vars.utilizationRate <= reserveData.maxUtilizationRate);
+    require(vars.utilizationRate <= reserveData.maxUtilizationRate, Errors.VL_EXCEED_MAX_UTILIZATION_RATE);
 
     (vars.currentLtv, vars.currentLiquidationThreshold, ) = nftData.configuration.getCollateralParams();
 

--- a/contracts/libraries/types/ConfigTypes.sol
+++ b/contracts/libraries/types/ConfigTypes.sol
@@ -20,6 +20,21 @@ library ConfigTypes {
     address underlyingAsset;
   }
 
+  struct ConfigNftInput {
+    address asset;
+    uint256 baseLTV;
+    uint256 liquidationThreshold;
+    uint256 liquidationBonus;
+    uint256 redeemDuration;
+    uint256 auctionDuration;
+    uint256 redeemFine;
+    uint256 redeemThreshold;
+    uint256 minBidFine;
+    uint256 maxSupply;
+    uint256 maxTokenId;
+    uint256 maxCollateralCap;
+  }
+
   struct UpdateBTokenInput {
     address asset;
     address implementation;

--- a/contracts/libraries/types/ConfigTypes.sol
+++ b/contracts/libraries/types/ConfigTypes.sol
@@ -16,6 +16,12 @@ library ConfigTypes {
     string debtTokenSymbol;
   }
 
+  struct ConfigReserveInput {
+    address asset;
+    uint256 reserveFactor;
+    uint256 maxUtilizationRate;
+  }
+
   struct InitNftInput {
     address underlyingAsset;
   }

--- a/contracts/libraries/types/DataTypes.sol
+++ b/contracts/libraries/types/DataTypes.sol
@@ -32,6 +32,7 @@ library DataTypes {
     uint8 id;
     uint256 maxSupply;
     uint256 maxTokenId;
+    uint256 maxCollateralCap;
   }
 
   struct ReserveConfigurationMap {

--- a/contracts/libraries/types/DataTypes.sol
+++ b/contracts/libraries/types/DataTypes.sol
@@ -21,6 +21,8 @@ library DataTypes {
     address interestRateAddress;
     //the id of the reserve. Represents the position in the list of the active reserves
     uint8 id;
+    // disable borrow when utilization rate exceeds max
+    uint256 maxUtilizationRate;
   }
 
   struct NftData {

--- a/contracts/protocol/LendPool.sol
+++ b/contracts/protocol/LendPool.sol
@@ -828,6 +828,10 @@ contract LendPool is
     _reserves[asset].interestRateAddress = rateAddress;
   }
 
+  function setReserveMaxUtilizationRate(address asset, uint256 maxUtilRate) external override onlyLendPoolConfigurator {
+    _reserves[asset].maxUtilizationRate = maxUtilRate;
+  }
+
   /**
    * @dev Sets the configuration bitmap of the reserve as a whole
    * - Only callable by the LendPoolConfigurator contract
@@ -857,7 +861,7 @@ contract LendPool is
     _nfts[asset].maxTokenId = maxTokenId;
   }
 
-  function setNftMaxCollateralCap(address asset, uint256 maxCap) external override {
+  function setNftMaxCollateralCap(address asset, uint256 maxCap) external override onlyLendPoolConfigurator {
     _nfts[asset].maxCollateralCap = maxCap;
   }
 

--- a/contracts/protocol/LendPool.sol
+++ b/contracts/protocol/LendPool.sol
@@ -857,6 +857,10 @@ contract LendPool is
     _nfts[asset].maxTokenId = maxTokenId;
   }
 
+  function setNftMaxCollateralCap(address asset, uint256 maxCap) external override {
+    _nfts[asset].maxCollateralCap = maxCap;
+  }
+
   function _addReserveToList(address asset) internal {
     uint256 reservesCount = _reservesCount;
 

--- a/contracts/protocol/LendPoolConfigurator.sol
+++ b/contracts/protocol/LendPoolConfigurator.sol
@@ -182,17 +182,14 @@ contract LendPoolConfigurator is Initializable, ILendPoolConfigurator {
     }
   }
 
-  function batchConfigReserve(ConfigReserveInput[] calldata inputs) external onlyPoolAdmin {
+  function batchConfigReserve(ConfigTypes.ConfigReserveInput[] calldata inputs) external onlyPoolAdmin {
     ILendPool cachedPool = _getLendPool();
-    for (uint256 i = 0; i < inputs.length; i++) {
-      DataTypes.ReserveConfigurationMap memory currentConfig = cachedPool.getReserveConfiguration(inputs[i].asset);
+    ConfiguratorLogic.executeBatchConfigReserve(cachedPool, inputs);
+  }
 
-      currentConfig.setReserveFactor(inputs[i].reserveFactor);
-
-      cachedPool.setReserveConfiguration(inputs[i].asset, currentConfig.data);
-
-      emit ReserveFactorChanged(inputs[i].asset, inputs[i].reserveFactor);
-    }
+  function setReserveMaxUtilizationRate(address[] calldata assets, uint256 maxUtilRate) external onlyRiskOrPoolAdmin {
+    ILendPool cachedPool = _getLendPool();
+    ConfiguratorLogic.executeSetReserveMaxUtilizationRate(cachedPool, assets, maxUtilRate);
   }
 
   function setActiveFlagOnNft(address[] calldata assets, bool flag) external onlyPoolAdmin {

--- a/contracts/protocol/LendPoolConfigurator.sol
+++ b/contracts/protocol/LendPoolConfigurator.sol
@@ -340,56 +340,14 @@ contract LendPoolConfigurator is Initializable, ILendPoolConfigurator {
     }
   }
 
-  function batchConfigNft(ConfigNftInput[] calldata inputs) external onlyPoolAdmin {
+  function batchConfigNft(ConfigTypes.ConfigNftInput[] calldata inputs) external onlyPoolAdmin {
     ILendPool cachedPool = _getLendPool();
-    for (uint256 i = 0; i < inputs.length; i++) {
-      DataTypes.NftConfigurationMap memory currentConfig = cachedPool.getNftConfiguration(inputs[i].asset);
+    ConfiguratorLogic.executeBatchConfigNft(cachedPool, inputs);
+  }
 
-      //validation of the parameters: the LTV can
-      //only be lower or equal than the liquidation threshold
-      //(otherwise a loan against the asset would cause instantaneous liquidation)
-      require(inputs[i].baseLTV <= inputs[i].liquidationThreshold, Errors.LPC_INVALID_CONFIGURATION);
-
-      if (inputs[i].liquidationThreshold != 0) {
-        //liquidation bonus must be smaller than or equal 100.00%
-        require(inputs[i].liquidationBonus <= PercentageMath.PERCENTAGE_FACTOR, Errors.LPC_INVALID_CONFIGURATION);
-      } else {
-        require(inputs[i].liquidationBonus == 0, Errors.LPC_INVALID_CONFIGURATION);
-      }
-
-      // collateral parameters
-      currentConfig.setLtv(inputs[i].baseLTV);
-      currentConfig.setLiquidationThreshold(inputs[i].liquidationThreshold);
-      currentConfig.setLiquidationBonus(inputs[i].liquidationBonus);
-
-      // auction parameters
-      currentConfig.setRedeemDuration(inputs[i].redeemDuration);
-      currentConfig.setAuctionDuration(inputs[i].auctionDuration);
-      currentConfig.setRedeemFine(inputs[i].redeemFine);
-      currentConfig.setRedeemThreshold(inputs[i].redeemThreshold);
-      currentConfig.setMinBidFine(inputs[i].minBidFine);
-
-      cachedPool.setNftConfiguration(inputs[i].asset, currentConfig.data);
-
-      emit NftConfigurationChanged(
-        inputs[i].asset,
-        inputs[i].baseLTV,
-        inputs[i].liquidationThreshold,
-        inputs[i].liquidationBonus
-      );
-      emit NftAuctionChanged(
-        inputs[i].asset,
-        inputs[i].redeemDuration,
-        inputs[i].auctionDuration,
-        inputs[i].redeemFine
-      );
-      emit NftRedeemThresholdChanged(inputs[i].asset, inputs[i].redeemThreshold);
-      emit NftMinBidFineChanged(inputs[i].asset, inputs[i].minBidFine);
-
-      // max limit
-      cachedPool.setNftMaxSupplyAndTokenId(inputs[i].asset, inputs[i].maxSupply, inputs[i].maxTokenId);
-      emit NftMaxSupplyAndTokenIdChanged(inputs[i].asset, inputs[i].maxSupply, inputs[i].maxTokenId);
-    }
+  function setNftMaxCollateralCap(address[] calldata assets, uint256 maxCap) external onlyRiskOrPoolAdmin {
+    ILendPool cachedPool = _getLendPool();
+    ConfiguratorLogic.executeSetNftMaxCollateralCap(cachedPool, assets, maxCap);
   }
 
   function setMaxNumberOfReserves(uint256 newVal) external onlyPoolAdmin {

--- a/helpers/init-helpers.ts
+++ b/helpers/init-helpers.ts
@@ -304,6 +304,7 @@ export const configureNftsByHelper = async (
     minBidFine: BigNumberish;
     maxSupply: BigNumberish;
     maxTokenId: BigNumberish;
+    maxCollateralCap: BigNumberish;
   }[] = [];
 
   console.log(`- Configure NFTs`);
@@ -344,6 +345,7 @@ export const configureNftsByHelper = async (
       minBidFine: minBidFine,
       maxSupply: maxSupply,
       maxTokenId: maxTokenId,
+      maxCollateralCap: 100,
     });
 
     tokens.push(tokenAddress);

--- a/helpers/init-helpers.ts
+++ b/helpers/init-helpers.ts
@@ -13,6 +13,8 @@ import { getContractAddressWithJsonFallback, rawInsertContractAddressInDb } from
 import { BigNumberish } from "ethers";
 import { ConfigNames } from "./configuration";
 import { deployRateStrategy } from "./contracts-deployments";
+import { oneRay, RAY } from "./constants";
+import BigNumber from "bignumber.js";
 
 export const getBTokenExtraParams = async (bTokenName: string, tokenAddress: tEthereumAddress) => {
   //console.log(bTokenName);
@@ -232,6 +234,7 @@ export const configureReservesByHelper = async (
   const inputParams: {
     asset: string;
     reserveFactor: BigNumberish;
+    maxUtilizationRate: BigNumberish;
   }[] = [];
 
   const assetsParams: string[] = [];
@@ -256,6 +259,7 @@ export const configureReservesByHelper = async (
     inputParams.push({
       asset: tokenAddress,
       reserveFactor: reserveFactor,
+      maxUtilizationRate: new BigNumber(0.75).multipliedBy(oneRay).toFixed(),
     });
 
     tokens.push(tokenAddress);

--- a/tasks/helpers/add-nft-to-pool.ts
+++ b/tasks/helpers/add-nft-to-pool.ts
@@ -91,6 +91,7 @@ task("helpers:add-nft-to-pool", "Add and config new nft asset to lend pool")
       minBidFine: BigNumberish;
       maxSupply: BigNumberish;
       maxTokenId: BigNumberish;
+      maxCollateralCap: BigNumberish;
     }[] = [
       {
         asset: asset,
@@ -104,6 +105,7 @@ task("helpers:add-nft-to-pool", "Add and config new nft asset to lend pool")
         minBidFine: nftParam.minBidFine,
         maxSupply: nftParam.maxSupply,
         maxTokenId: nftParam.maxTokenId,
+        maxCollateralCap: 100,
       },
     ];
     await waitForTx(await lendPoolConfiguratorProxy.connect(poolAdminSigner).batchConfigNft(cfgInputParams));

--- a/tasks/helpers/add-reserve-to-pool.ts
+++ b/tasks/helpers/add-reserve-to-pool.ts
@@ -16,6 +16,7 @@ import { getEthersSignerByAddress, getParamPerNetwork } from "../../helpers/cont
 import { getNowTimeInSeconds, notFalsyOrZeroAddress, waitForTx } from "../../helpers/misc-utils";
 import { eContractid, eNetwork, IReserveParams } from "../../helpers/types";
 import { strategyReserveParams } from "../../markets/bend/reservesConfigs";
+import BigNumber from "bignumber.js";
 
 task("helpers:add-reserve-to-pool", "Add and config new reserve asset to lend pool")
   .addParam("pool", `Pool name to retrieve configuration, supported: ${Object.values(ConfigNames)}`)
@@ -112,7 +113,7 @@ task("helpers:add-reserve-to-pool", "Add and config new reserve asset to lend po
       {
         asset: asset,
         reserveFactor: reserveParam.reserveFactor,
-        maxUtilizationRate: oneRay,
+        maxUtilizationRate: new BigNumber(0.75).multipliedBy(oneRay).toFixed(),
       },
     ];
     console.log("Reserve cfgInputParams:", cfgInputParams);

--- a/tasks/helpers/add-reserve-to-pool.ts
+++ b/tasks/helpers/add-reserve-to-pool.ts
@@ -1,7 +1,7 @@
 import { BigNumberish } from "@ethersproject/bignumber";
 import { task } from "hardhat/config";
 import { ConfigNames, getProviderRegistryAddress, loadPoolConfig } from "../../helpers/configuration";
-import { ADDRESS_ID_PUNK_GATEWAY } from "../../helpers/constants";
+import { ADDRESS_ID_PUNK_GATEWAY, oneRay } from "../../helpers/constants";
 import { deployInterestRate } from "../../helpers/contracts-deployments";
 import {
   getBToken,
@@ -107,10 +107,12 @@ task("helpers:add-reserve-to-pool", "Add and config new reserve asset to lend po
     let cfgInputParams: {
       asset: string;
       reserveFactor: BigNumberish;
+      maxUtilizationRate: BigNumberish;
     }[] = [
       {
         asset: asset,
         reserveFactor: reserveParam.reserveFactor,
+        maxUtilizationRate: oneRay,
       },
     ];
     console.log("Reserve cfgInputParams:", cfgInputParams);

--- a/tasks/helpers/encode-add-nft-to-pool.ts
+++ b/tasks/helpers/encode-add-nft-to-pool.ts
@@ -82,6 +82,7 @@ task("helpers:encode-add-nft-to-pool", "Init and config new nft asset to lend po
       minBidFine: BigNumberish;
       maxSupply: BigNumberish;
       maxTokenId: BigNumberish;
+      maxCollateralCap: BigNumberish;
     }[] = [
       {
         asset: asset,
@@ -95,6 +96,7 @@ task("helpers:encode-add-nft-to-pool", "Init and config new nft asset to lend po
         minBidFine: nftParam.minBidFine,
         maxSupply: nftParam.maxSupply,
         maxTokenId: nftParam.maxTokenId,
+        maxCollateralCap: 100,
       },
     ];
     const batchCfgNftEncodeData = lendPoolConfiguratorProxy.interface.encodeFunctionData("batchConfigNft", [

--- a/test/configurator-nft.spec.ts
+++ b/test/configurator-nft.spec.ts
@@ -21,6 +21,7 @@ makeSuite("Configurator-NFT", (testEnv: TestEnv) => {
     minBidFine: BigNumberish;
     maxSupply: BigNumberish;
     maxTokenId: BigNumberish;
+    maxCollateralCap: BigNumberish;
   }[] = [
     {
       asset: "",
@@ -34,6 +35,7 @@ makeSuite("Configurator-NFT", (testEnv: TestEnv) => {
       minBidFine: 0,
       maxSupply: 10000,
       maxTokenId: 9999,
+      maxCollateralCap: 100,
     },
   ];
 

--- a/test/configurator-nft.spec.ts
+++ b/test/configurator-nft.spec.ts
@@ -39,7 +39,8 @@ makeSuite("Configurator-NFT", (testEnv: TestEnv) => {
     },
   ];
 
-  const { CALLER_NOT_POOL_ADMIN, LPC_INVALID_CONFIGURATION, LPC_NFT_LIQUIDITY_NOT_0 } = ProtocolErrors;
+  const { CALLER_NOT_POOL_ADMIN, CALLER_NOT_RISK_OR_POOL_ADMIN, LPC_INVALID_CONFIGURATION, LPC_NFT_LIQUIDITY_NOT_0 } =
+    ProtocolErrors;
 
   it("Deactivates the BAYC NFT", async () => {
     const { configurator, bayc, dataProvider } = testEnv;
@@ -288,6 +289,21 @@ makeSuite("Configurator-NFT", (testEnv: TestEnv) => {
     await expect(configurator.setActiveFlagOnNft([bayc.address], false), LPC_NFT_LIQUIDITY_NOT_0).to.be.revertedWith(
       LPC_NFT_LIQUIDITY_NOT_0
     );
+  });
+
+  it("Config setNftMaxCollateralCap invalid value", async () => {
+    const { configurator, weth, pool } = testEnv;
+    await configurator.setNftMaxCollateralCap([weth.address], 512);
+    const { maxCollateralCap } = await pool.getNftData(weth.address);
+    expect(maxCollateralCap).to.be.equal(512);
+  });
+
+  it("Check the onlyPoolAdmin on setNftMaxCollateralCap ", async () => {
+    const { configurator, users, weth } = testEnv;
+    await expect(
+      configurator.connect(users[2].signer).setNftMaxCollateralCap([weth.address], 512),
+      CALLER_NOT_RISK_OR_POOL_ADMIN
+    ).to.be.revertedWith(CALLER_NOT_RISK_OR_POOL_ADMIN);
   });
 
   it("Config setMaxNumberOfNfts valid value", async () => {

--- a/test/foundry/ListingUSDTFork.t.sol
+++ b/test/foundry/ListingUSDTFork.t.sol
@@ -96,8 +96,12 @@ contract ListingUSDTForkTest is Test {
     vm.prank(timelockController7DAddress);
     configurator.batchInitReserve(initInputs);
 
-    ILendPoolConfigurator.ConfigReserveInput[] memory cfgInputs = new ILendPoolConfigurator.ConfigReserveInput[](1);
-    cfgInputs[0] = ILendPoolConfigurator.ConfigReserveInput({asset: usdtTokenAddress, reserveFactor: 3000});
+    ConfigTypes.ConfigReserveInput[] memory cfgInputs = new ConfigTypes.ConfigReserveInput[](1);
+    cfgInputs[0] = ConfigTypes.ConfigReserveInput({
+      asset: usdtTokenAddress,
+      reserveFactor: 3000,
+      maxUtilizationRate: 1e27
+    });
     vm.prank(timelockController7DAddress);
     configurator.batchConfigReserve(cfgInputs);
 


### PR DESCRIPTION
* Adding max collateral cap to NFT collection, e.g max 100 punks, 200 bayc, 50 azuki;
* Adding max utilization rate to reserve, e.g. max 75% for ETH, USDT;